### PR TITLE
feat(BRD-12): AI Chat UI updates

### DIFF
--- a/.claude/commands/complete-jira-issue.md
+++ b/.claude/commands/complete-jira-issue.md
@@ -1,2 +1,9 @@
+---
+title: complete-jira-issue
+description: Command used to mark the jira issue complete and update the AGENTS.md with the status.
+---
+
+<instruction>
 update the jira issue $1 to completed. Then update the @AGENTS.md with a brief and concise summary status update in the  
  Implementation Status section.
+</instruction>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,10 @@ Multi-stage Dockerfile with standalone Next.js output. Lazy DB connection fix fo
 
 Adds `scripts/seed.ts` that clears all data and re-seeds 4 test users (Alice, Bob, Carol, David) each with 2 birding events and multiple bird sightings. Uses `auth.api.signUpEmail()` for proper Better Auth password hashing. All users share password `password1234`. Run with `pnpm db:seed`.
 
+### BRD-12 - AI Chat UI Updates (complete, PR #8)
+
+Moved `BirdChatWidget` to the top of each bird sighting card so users can identify without scrolling. Removed `useEffect` auto-scroll. `parseIdentification` now extracts the AI summary text before the JSON block and returns it as `summary`. The `onIdentified` callback now also auto-populates the bird sighting `notes` field with the AI summary.
+
 ### BRD-3 - Better Auth (complete, PR #4)
 
 Replaced mock auth with Better Auth. Email/password + Google OAuth. New /signup page. DB schema updated with Better Auth tables. Startup migration via scripts/migrate.ts.

--- a/src/components/BirdChatWidget.tsx
+++ b/src/components/BirdChatWidget.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import styles from "./BirdChatWidget.module.css";
 import { parseIdentification } from "@/lib/chat";
 import type { BirdIdentification } from "@/lib/chat";
@@ -19,11 +19,6 @@ export default function BirdChatWidget({ onIdentified }: Props) {
   const [input, setInput] = useState("");
   const [isStreaming, setIsStreaming] = useState(false);
   const [identified, setIdentified] = useState(false);
-  const bottomRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
 
   async function send() {
     const text = input.trim();
@@ -116,7 +111,6 @@ export default function BirdChatWidget({ onIdentified }: Props) {
             )}
           </div>
         ))}
-        <div ref={bottomRef} />
       </div>
       {identified ? (
         <p className={styles.identified}>Bird identified — fields updated above.</p>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -146,6 +146,13 @@ export default function EventForm() {
                 </button>
               )}
             </div>
+            <BirdChatWidget
+              onIdentified={({ type, species, summary }) => {
+                updateBird(index, "type", type);
+                updateBird(index, "species", species);
+                if (summary) updateBird(index, "notes", summary);
+              }}
+            />
             <div className={styles.birdGrid}>
               <div className={styles.field}>
                 <label htmlFor={`bird-type-${index}`} className={styles.label}>
@@ -254,12 +261,6 @@ export default function EventForm() {
                 placeholder="Optional notes about this sighting"
               />
             </div>
-            <BirdChatWidget
-              onIdentified={({ type, species }) => {
-                updateBird(index, "type", type);
-                updateBird(index, "species", species);
-              }}
-            />
           </div>
         ))}
 

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,6 +1,7 @@
 export interface BirdIdentification {
   type: string;
   species: string;
+  summary: string;
 }
 
 /** Parses the JSON identification block the AI embeds in its final response. */
@@ -10,7 +11,8 @@ export function parseIdentification(text: string): BirdIdentification | null {
   try {
     const data = JSON.parse(match[0]);
     if (data.identified && data.type && data.species) {
-      return { type: data.type, species: data.species };
+      const summary = text.slice(0, match.index).trim();
+      return { type: data.type, species: data.species, summary };
     }
   } catch {
     // malformed JSON

--- a/src/tests/unit/chat.test.ts
+++ b/src/tests/unit/chat.test.ts
@@ -13,6 +13,16 @@ It has a red breast and dark back.`;
     expect(parseIdentification(text)).toEqual({
       type: "Songbird",
       species: "American Robin",
+      summary: "Based on your description, I can identify this bird.",
+    });
+  });
+
+  it("includes empty summary when JSON block is at start", () => {
+    const text = `{"identified": true, "type": "Raptor", "species": "Osprey"}`;
+    expect(parseIdentification(text)).toEqual({
+      type: "Raptor",
+      species: "Osprey",
+      summary: "",
     });
   });
 


### PR DESCRIPTION
## Summary

- Move AI chat widget to the top of each bird sighting card so users can identify without scrolling
- Remove `useEffect` auto-scroll (no longer needed with chat at top of form)
- `parseIdentification` now extracts the AI summary text (text before the JSON block) and returns it as `summary`
- `onIdentified` callback now also populates the bird sighting `notes` field with the AI summary

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] TypeScript compiles cleanly (`pnpm tsc --noEmit`)
- [ ] Unit tests updated to assert new `summary` field in `parseIdentification` return value
- [ ] Manually verify: chat widget appears above bird fields on `/events/new`
- [ ] Manually verify: after AI identifies a bird, type, species, and notes fields are all populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)