### PR TITLE
feat(BRD-10): improve editing of events and bird sightings

### DIFF
--- a/.claude/commands/implement-jira-issue.md
+++ b/.claude/commands/implement-jira-issue.md
@@ -3,7 +3,7 @@ title: implement-jira-issue
 description: command used to instruct Claude Code to run the /feature-dev command using the given insructions to implement the Jira issue. The user will input the Jira issue  id and extra instructions are optional
 ---
 
-run the /feature-dev plugin with the following instructions:
+run the /feature-dev plugin with the below instructions. Make sure to not skip any steps in the feature-dev process.
 
 <instructions>
 -Implement Jira issue $1.

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+#claude
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,15 @@ The database should use SQLLite with Drizzle ORM and be created from scratch eac
 The authentication currently has a mock auth system but will use Better Auth in future.
 Always use server side authentication. Do not implement client side authentication unless told specifically to do so.
 All server pages, actions, routes and data access layers should be implemented with server authentication.
+React.FormEvent is deprecated, if using in a Form to handle event, use React.SubmitEvent.
+-example:
+
+```tsx
+function handleSubmit(e: React.SubmitEven) {
+  e.preventDefault();
+  //...rest of function
+}
+```
 
 ## Color Scheme
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,10 @@ Moved `BirdChatWidget` to the top of each bird sighting card so users can identi
 
 Renamed `vitest.config.ts` to `vitest.config.mts` to force ESM loading. Root cause: vitest@4.x depends on `std-env@4.0.0` (ESM-only); vite@7 was loading the config as CJS and calling `require()` on it. All 17 unit tests pass.
 
+### BRD-10 - Improve Editing of Events and Bird Sightings (complete, PR #10)
+
+Events can now be created without bird sightings (birds optional, form starts empty). Dashboard cards have Edit, Delete, and Add Bird actions on all three views (Timeline, Species, Location). Edit navigates to `/events/[id]/edit`, Add Bird to `/events/[id]/add-bird`. Delete uses a CSS-modules confirmation dialog. Individual bird sightings can also be deleted. New DAL layer (`src/lib/dal/events.ts`) fixes a security bug where all users' birds were fetched. PUT is wrapped in a Drizzle transaction for atomicity.
+
 ### BRD-3 - Better Auth (complete, PR #4)
 
 Replaced mock auth with Better Auth. Email/password + Google OAuth. New /signup page. DB schema updated with Better Auth tables. Startup migration via scripts/migrate.ts.

--- a/src/app/api/birds/[id]/route.ts
+++ b/src/app/api/birds/[id]/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { birdingEvents, birdEntries } from "@/db/schema";
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const birdId = parseInt(id, 10);
+  if (isNaN(birdId)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  // Single query: verify the bird exists and belongs to the session user
+  const [row] = await db
+    .select({ birdId: birdEntries.id })
+    .from(birdEntries)
+    .innerJoin(birdingEvents, eq(birdEntries.eventId, birdingEvents.id))
+    .where(and(eq(birdEntries.id, birdId), eq(birdingEvents.userId, session.user.id)));
+
+  if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await db.delete(birdEntries).where(eq(birdEntries.id, birdId));
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/events/[id]/birds/route.ts
+++ b/src/app/api/events/[id]/birds/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { birdingEvents, birdEntries } from "@/db/schema";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const eventId = parseInt(id, 10);
+  if (isNaN(eventId)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  const [event] = await db
+    .select()
+    .from(birdingEvents)
+    .where(and(eq(birdingEvents.id, eventId), eq(birdingEvents.userId, session.user.id)));
+
+  if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { type, species, locationName, lat, lng, dateStamp, notes } = await req.json();
+
+  const [bird] = await db
+    .insert(birdEntries)
+    .values({
+      eventId,
+      type,
+      species,
+      locationName,
+      lat: lat ?? null,
+      lng: lng ?? null,
+      dateStamp,
+      notes: notes ?? null,
+    })
+    .returning();
+
+  return NextResponse.json({ ok: true, birdId: bird.id });
+}

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { birdingEvents, birdEntries } from "@/db/schema";
+
+type BirdPayload = {
+  type: string;
+  species: string;
+  locationName: string;
+  lat?: number | null;
+  lng?: number | null;
+  dateStamp: string;
+  notes?: string | null;
+};
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const eventId = parseInt(id, 10);
+  if (isNaN(eventId)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  const [event] = await db
+    .select()
+    .from(birdingEvents)
+    .where(and(eq(birdingEvents.id, eventId), eq(birdingEvents.userId, session.user.id)));
+
+  if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const { title, date, notes, birds } = await req.json();
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(birdingEvents)
+      .set({ title, date, notes: notes ?? null })
+      .where(eq(birdingEvents.id, eventId));
+
+    await tx.delete(birdEntries).where(eq(birdEntries.eventId, eventId));
+
+    if (birds && birds.length > 0) {
+      await tx.insert(birdEntries).values(
+        birds.map((b: BirdPayload) => ({
+          eventId,
+          type: b.type,
+          species: b.species,
+          locationName: b.locationName,
+          lat: b.lat ?? null,
+          lng: b.lng ?? null,
+          dateStamp: b.dateStamp,
+          notes: b.notes ?? null,
+        })),
+      );
+    }
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const eventId = parseInt(id, 10);
+  if (isNaN(eventId)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  const [event] = await db
+    .select()
+    .from(birdingEvents)
+    .where(and(eq(birdingEvents.id, eventId), eq(birdingEvents.userId, session.user.id)));
+
+  if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await db.delete(birdingEvents).where(eq(birdingEvents.id, eventId));
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,5 @@
 import { requireAuth } from "../../lib/session";
-import { db } from "../../db";
-import { birdingEvents, birdEntries } from "../../db/schema";
-import { eq } from "drizzle-orm";
+import { getUserEvents } from "../../lib/dal/events";
 import Link from "next/link";
 import LogoutButton from "../../components/LogoutButton";
 import DashboardTabs from "../../components/DashboardTabs";
@@ -15,18 +13,7 @@ export default async function DashboardPage({
   const session = await requireAuth();
   const { view = "timeline" } = await searchParams;
 
-  const events = await db
-    .select()
-    .from(birdingEvents)
-    .where(eq(birdingEvents.userId, session.user.id))
-    .orderBy(birdingEvents.date);
-
-  const birds = await db.select().from(birdEntries);
-
-  const eventsWithBirds = events.map((event) => ({
-    ...event,
-    birds: birds.filter((b) => b.eventId === event.id),
-  }));
+  const eventsWithBirds = await getUserEvents(session.user.id);
 
   return (
     <div className={styles.page}>

--- a/src/app/events/[id]/add-bird/page.module.css
+++ b/src/app/events/[id]/add-bird/page.module.css
@@ -1,0 +1,34 @@
+.page {
+  min-height: 100vh;
+}
+
+.header {
+  background: white;
+  border-bottom: 1px solid #e8e8e4;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: #209dd7;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #032147;
+}
+
+.main {
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}

--- a/src/app/events/[id]/add-bird/page.tsx
+++ b/src/app/events/[id]/add-bird/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/lib/session";
+import { getEventWithBirds } from "@/lib/dal/events";
+import AddBirdForm from "@/components/AddBirdForm";
+import Link from "next/link";
+import styles from "./page.module.css";
+
+export default async function AddBirdPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await requireAuth();
+  const { id } = await params;
+  const eventId = parseInt(id, 10);
+
+  if (isNaN(eventId)) notFound();
+
+  const data = await getEventWithBirds(eventId, session.user.id);
+  if (!data) notFound();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard" className={styles.back}>
+          ← Back to Dashboard
+        </Link>
+        <h1 className={styles.title}>Add Bird to: {data.title}</h1>
+      </header>
+      <main className={styles.main}>
+        <AddBirdForm eventId={eventId} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/events/[id]/edit/page.module.css
+++ b/src/app/events/[id]/edit/page.module.css
@@ -1,0 +1,34 @@
+.page {
+  min-height: 100vh;
+}
+
+.header {
+  background: white;
+  border-bottom: 1px solid #e8e8e4;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: #209dd7;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #032147;
+}
+
+.main {
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}

--- a/src/app/events/[id]/edit/page.tsx
+++ b/src/app/events/[id]/edit/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/lib/session";
+import { getEventWithBirds } from "@/lib/dal/events";
+import EventForm from "@/components/EventForm";
+import Link from "next/link";
+import styles from "./page.module.css";
+
+export default async function EditEventPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await requireAuth();
+  const { id } = await params;
+  const eventId = parseInt(id, 10);
+
+  if (isNaN(eventId)) notFound();
+
+  const data = await getEventWithBirds(eventId, session.user.id);
+  if (!data) notFound();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard" className={styles.back}>
+          ← Back to Dashboard
+        </Link>
+        <h1 className={styles.title}>Edit Event</h1>
+      </header>
+      <main className={styles.main}>
+        <EventForm initialData={{ event: data, birds: data.birds }} />
+      </main>
+    </div>
+  );
+}

--- a/src/components/AddBirdForm.module.css
+++ b/src/components/AddBirdForm.module.css
@@ -1,10 +1,4 @@
 .form {
-  display: flex;
-  flex-direction: column;
-  gap: 1.5rem;
-}
-
-.section {
   background: white;
   border-radius: 10px;
   padding: 1.5rem;
@@ -14,12 +8,16 @@
   gap: 1rem;
 }
 
-.sectionTitle {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #444;
-  padding-bottom: 0.5rem;
-  border-bottom: 1px solid #f0f0ea;
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+@media (max-width: 540px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 .field {
@@ -61,69 +59,6 @@
   border-color: #209dd7;
 }
 
-.birdCard {
-  border: 1px solid #e8e8e4;
-  border-radius: 8px;
-  padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  background: #fafaf8;
-}
-
-.birdCardHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.birdIndex {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: #209dd7;
-}
-
-.removeBtn {
-  background: none;
-  border: none;
-  color: #c0392b;
-  font-size: 0.8rem;
-  padding: 0.2rem 0.5rem;
-  border-radius: 4px;
-}
-
-.removeBtn:hover {
-  background: #fde8e8;
-}
-
-.birdGrid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
-}
-
-@media (max-width: 540px) {
-  .birdGrid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.addBirdBtn {
-  background: none;
-  border: 1px dashed #209dd7;
-  color: #209dd7;
-  padding: 0.6rem;
-  border-radius: 6px;
-  font-size: 0.9rem;
-  font-weight: 500;
-  width: 100%;
-  transition: background 0.15s;
-}
-
-.addBirdBtn:hover {
-  background: #f0f7f3;
-}
-
 .error {
   color: #c0392b;
   font-size: 0.875rem;
@@ -133,7 +68,7 @@
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
-  padding-bottom: 2rem;
+  padding-top: 0.5rem;
 }
 
 .cancelBtn {
@@ -143,6 +78,7 @@
   border-radius: 6px;
   font-size: 0.95rem;
   color: #555;
+  cursor: pointer;
 }
 
 .cancelBtn:hover {
@@ -157,6 +93,7 @@
   border-radius: 6px;
   font-size: 0.95rem;
   font-weight: 600;
+  cursor: pointer;
   transition: background 0.15s;
 }
 

--- a/src/components/AddBirdForm.tsx
+++ b/src/components/AddBirdForm.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import { useState, startTransition } from "react";
+import { useRouter } from "next/navigation";
+import BirdChatWidget from "./BirdChatWidget";
+import styles from "./AddBirdForm.module.css";
+
+interface Props {
+  eventId: number;
+}
+
+export default function AddBirdForm({ eventId }: Props) {
+  const router = useRouter();
+  const [type, setType] = useState("");
+  const [species, setSpecies] = useState("");
+  const [locationName, setLocationName] = useState("");
+  const [lat, setLat] = useState("");
+  const [lng, setLng] = useState("");
+  const [dateStamp, setDateStamp] = useState(new Date().toISOString().slice(0, 10));
+  const [notes, setNotes] = useState("");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setSaving(true);
+
+    startTransition(async () => {
+      const res = await fetch(`/api/events/${eventId}/birds`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          species,
+          locationName,
+          lat: lat !== "" ? parseFloat(lat) : null,
+          lng: lng !== "" ? parseFloat(lng) : null,
+          dateStamp,
+          notes,
+        }),
+      });
+
+      setSaving(false);
+
+      if (res.ok) {
+        router.push("/dashboard");
+        router.refresh();
+      } else {
+        setError("Failed to save bird sighting. Please try again.");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <BirdChatWidget
+        onIdentified={({ type: t, species: s, summary }) => {
+          setType(t);
+          setSpecies(s);
+          if (summary) setNotes(summary);
+        }}
+      />
+
+      <div className={styles.grid}>
+        <div className={styles.field}>
+          <label htmlFor="type" className={styles.label}>
+            Type
+          </label>
+          <input
+            id="type"
+            type="text"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. Raptor"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="species" className={styles.label}>
+            Species
+          </label>
+          <input
+            id="species"
+            type="text"
+            value={species}
+            onChange={(e) => setSpecies(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. Red-tailed Hawk"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="locationName" className={styles.label}>
+            Location Name
+          </label>
+          <input
+            id="locationName"
+            type="text"
+            value={locationName}
+            onChange={(e) => setLocationName(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. Central Park, NY"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="dateStamp" className={styles.label}>
+            Date Observed
+          </label>
+          <input
+            id="dateStamp"
+            type="date"
+            value={dateStamp}
+            onChange={(e) => setDateStamp(e.target.value)}
+            className={styles.input}
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="lat" className={styles.label}>
+            Latitude (optional)
+          </label>
+          <input
+            id="lat"
+            type="number"
+            step="any"
+            value={lat}
+            onChange={(e) => setLat(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. 40.7851"
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="lng" className={styles.label}>
+            Longitude (optional)
+          </label>
+          <input
+            id="lng"
+            type="number"
+            step="any"
+            value={lng}
+            onChange={(e) => setLng(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. -73.9683"
+          />
+        </div>
+      </div>
+
+      <div className={styles.field}>
+        <label htmlFor="notes" className={styles.label}>
+          Notes
+        </label>
+        <textarea
+          id="notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className={styles.textarea}
+          rows={3}
+          placeholder="Optional notes about this sighting"
+        />
+      </div>
+
+      {error && <p className={styles.error}>{error}</p>}
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          onClick={() => router.push("/dashboard")}
+          className={styles.cancelBtn}
+        >
+          Cancel
+        </button>
+        <button type="submit" disabled={saving} className={styles.saveBtn}>
+          {saving ? "Saving…" : "Add Bird"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/AddBirdForm.tsx
+++ b/src/components/AddBirdForm.tsx
@@ -16,12 +16,14 @@ export default function AddBirdForm({ eventId }: Props) {
   const [locationName, setLocationName] = useState("");
   const [lat, setLat] = useState("");
   const [lng, setLng] = useState("");
-  const [dateStamp, setDateStamp] = useState(new Date().toISOString().slice(0, 10));
+  const [dateStamp, setDateStamp] = useState(
+    new Date().toISOString().slice(0, 10),
+  );
   const [notes, setNotes] = useState("");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.SubmitEvent) {
     e.preventDefault();
     setError("");
     setSaving(true);

--- a/src/components/BirdActions.module.css
+++ b/src/components/BirdActions.module.css
@@ -1,0 +1,21 @@
+.deleteBtn {
+  padding: 0.2rem 0.5rem;
+  border: 1px solid #c0392b;
+  border-radius: 4px;
+  background: white;
+  color: #c0392b;
+  font-size: 0.75rem;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.deleteBtn:hover {
+  background: #c0392b;
+  color: white;
+}
+
+.error {
+  font-size: 0.75rem;
+  color: #c0392b;
+  margin-top: 0.2rem;
+}

--- a/src/components/BirdActions.tsx
+++ b/src/components/BirdActions.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import ConfirmDialog from "./ConfirmDialog";
+import styles from "./BirdActions.module.css";
+
+interface Props {
+  birdId: number;
+  birdSpecies: string;
+}
+
+export default function BirdActions({ birdId, birdSpecies }: Props) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDelete() {
+    const res = await fetch(`/api/birds/${birdId}`, { method: "DELETE" });
+    if (!res.ok) {
+      setConfirming(false);
+      setError("Failed to delete. Please try again.");
+      return;
+    }
+    setConfirming(false);
+    router.refresh();
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setConfirming(true)}
+        className={styles.deleteBtn}
+      >
+        Delete
+      </button>
+      {error && <p className={styles.error}>{error}</p>}
+      <ConfirmDialog
+        open={confirming}
+        message={`Delete sighting of "${birdSpecies}"?`}
+        onConfirm={handleDelete}
+        onCancel={() => setConfirming(false)}
+      />
+    </>
+  );
+}

--- a/src/components/ConfirmDialog.module.css
+++ b/src/components/ConfirmDialog.module.css
@@ -1,0 +1,61 @@
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 33, 71, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.dialog {
+  border: none;
+  border-radius: 8px;
+  padding: 1.5rem;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  background: white;
+}
+
+.message {
+  margin: 0 0 1.25rem;
+  font-size: 0.95rem;
+  color: #032147;
+  line-height: 1.5;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.cancelBtn {
+  padding: 0.5rem 1rem;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+  background: white;
+  color: #555;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.cancelBtn:hover {
+  background: #f5f5f5;
+}
+
+.confirmBtn {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  background: #753991;
+  color: white;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.confirmBtn:hover {
+  background: #5e2e74;
+}

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import styles from "./ConfirmDialog.module.css";
+
+interface Props {
+  open: boolean;
+  message: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function ConfirmDialog({ open, message, onConfirm, onCancel }: Props) {
+  if (!open) return null;
+
+  return (
+    <div className={styles.backdrop} onClick={onCancel}>
+      <dialog open className={styles.dialog} onClick={(e) => e.stopPropagation()}>
+        <p className={styles.message}>{message}</p>
+        <div className={styles.actions}>
+          <button type="button" onClick={onCancel} className={styles.cancelBtn}>
+            Cancel
+          </button>
+          <button type="button" onClick={onConfirm} className={styles.confirmBtn}>
+            Delete
+          </button>
+        </div>
+      </dialog>
+    </div>
+  );
+}

--- a/src/components/DashboardTabs.module.css
+++ b/src/components/DashboardTabs.module.css
@@ -22,9 +22,9 @@
 }
 
 .tab.active {
-  color: #2c6e49;
+  color: #209dd7;
   font-weight: 600;
-  border-bottom-color: #2c6e49;
+  border-bottom-color: #209dd7;
 }
 
 .content {
@@ -92,8 +92,17 @@
 
 .birdItem {
   display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.birdItemInfo {
+  display: flex;
   flex-direction: column;
   gap: 0.15rem;
+  flex: 1;
 }
 
 .birdName {

--- a/src/components/DashboardTabs.tsx
+++ b/src/components/DashboardTabs.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRouter, usePathname } from "next/navigation";
-import type { BirdingEvent, BirdEntry } from "@/db/schema";
+import type { BirdEntry } from "@/db/schema";
+import type { EventWithBirds } from "@/lib/dal/events";
+import EventActions from "./EventActions";
+import BirdActions from "./BirdActions";
 import styles from "./DashboardTabs.module.css";
-
-type EventWithBirds = BirdingEvent & { birds: BirdEntry[] };
 
 interface Props {
   view: string;
@@ -68,12 +69,16 @@ function TimelineView({ events }: { events: EventWithBirds[] }) {
             <ul className={styles.birdList}>
               {event.birds.map((bird) => (
                 <li key={bird.id} className={styles.birdItem}>
-                  <span className={styles.birdName}>{bird.species}</span>
-                  <span className={styles.birdMeta}>{bird.type} · {bird.locationName}</span>
+                  <div className={styles.birdItemInfo}>
+                    <span className={styles.birdName}>{bird.species}</span>
+                    <span className={styles.birdMeta}>{bird.type} · {bird.locationName}</span>
+                  </div>
+                  <BirdActions birdId={bird.id} birdSpecies={bird.species} />
                 </li>
               ))}
             </ul>
           )}
+          <EventActions eventId={event.id} eventTitle={event.title} />
         </div>
       ))}
     </div>
@@ -103,9 +108,12 @@ function SpeciesView({ events }: { events: EventWithBirds[] }) {
           <ul className={styles.birdList}>
             {entries.map(({ bird, eventTitle, eventDate }) => (
               <li key={bird.id} className={styles.birdItem}>
-                <span className={styles.birdName}>{eventTitle}</span>
-                <span className={styles.birdMeta}>{eventDate} · {bird.locationName}</span>
-                {bird.notes && <span className={styles.birdNotes}>{bird.notes}</span>}
+                <div className={styles.birdItemInfo}>
+                  <span className={styles.birdName}>{eventTitle}</span>
+                  <span className={styles.birdMeta}>{eventDate} · {bird.locationName}</span>
+                  {bird.notes && <span className={styles.birdNotes}>{bird.notes}</span>}
+                </div>
+                <BirdActions birdId={bird.id} birdSpecies={bird.species} />
               </li>
             ))}
           </ul>
@@ -134,17 +142,20 @@ function LocationView({ events }: { events: EventWithBirds[] }) {
     <div className={styles.list}>
       {sorted.map(([location, entries]) => (
         <div key={location} className={styles.card}>
-          <h2 className={styles.cardTitle}>📍 {location}</h2>
+          <h2 className={styles.cardTitle}>{location}</h2>
           <ul className={styles.birdList}>
             {entries.map(({ bird, eventTitle, eventDate }) => (
               <li key={bird.id} className={styles.birdItem}>
-                <span className={styles.birdName}>{bird.species} ({bird.type})</span>
-                <span className={styles.birdMeta}>{eventTitle} · {eventDate}</span>
-                {bird.lat != null && bird.lng != null && (
-                  <span className={styles.birdMeta}>
-                    {bird.lat.toFixed(4)}, {bird.lng.toFixed(4)}
-                  </span>
-                )}
+                <div className={styles.birdItemInfo}>
+                  <span className={styles.birdName}>{bird.species} ({bird.type})</span>
+                  <span className={styles.birdMeta}>{eventTitle} · {eventDate}</span>
+                  {bird.lat != null && bird.lng != null && (
+                    <span className={styles.birdMeta}>
+                      {bird.lat.toFixed(4)}, {bird.lng.toFixed(4)}
+                    </span>
+                  )}
+                </div>
+                <BirdActions birdId={bird.id} birdSpecies={bird.species} />
               </li>
             ))}
           </ul>

--- a/src/components/EventActions.module.css
+++ b/src/components/EventActions.module.css
@@ -1,0 +1,46 @@
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.75rem;
+}
+
+.btn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #209dd7;
+  border-radius: 5px;
+  background: white;
+  color: #209dd7;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.btn:hover {
+  background: #209dd7;
+  color: white;
+}
+
+.dangerBtn {
+  padding: 0.35rem 0.75rem;
+  border: 1px solid #c0392b;
+  border-radius: 5px;
+  background: white;
+  color: #c0392b;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.dangerBtn:hover {
+  background: #c0392b;
+  color: white;
+}
+
+.error {
+  font-size: 0.8rem;
+  color: #c0392b;
+  margin-top: 0.25rem;
+}

--- a/src/components/EventActions.tsx
+++ b/src/components/EventActions.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import ConfirmDialog from "./ConfirmDialog";
+import styles from "./EventActions.module.css";
+
+interface Props {
+  eventId: number;
+  eventTitle: string;
+}
+
+export default function EventActions({ eventId, eventTitle }: Props) {
+  const router = useRouter();
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleDelete() {
+    const res = await fetch(`/api/events/${eventId}`, { method: "DELETE" });
+    if (!res.ok) {
+      setConfirming(false);
+      setError("Failed to delete event. Please try again.");
+      return;
+    }
+    setConfirming(false);
+    router.refresh();
+  }
+
+  return (
+    <>
+      <div className={styles.actions}>
+        <Link href={`/events/${eventId}/add-bird`} className={styles.btn}>
+          + Add Bird
+        </Link>
+        <Link href={`/events/${eventId}/edit`} className={styles.btn}>
+          Edit
+        </Link>
+        <button
+          type="button"
+          onClick={() => setConfirming(true)}
+          className={styles.dangerBtn}
+        >
+          Delete
+        </button>
+      </div>
+      {error && <p className={styles.error}>{error}</p>}
+      <ConfirmDialog
+        open={confirming}
+        message={`Delete event "${eventTitle}"? This will also delete all bird sightings.`}
+        onConfirm={handleDelete}
+        onCancel={() => setConfirming(false)}
+      />
+    </>
+  );
+}

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -64,7 +64,11 @@ export default function EventForm({ initialData }: Props) {
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
 
-  function updateBird(index: number, field: keyof BirdFormEntry, value: string) {
+  function updateBird(
+    index: number,
+    field: keyof BirdFormEntry,
+    value: string,
+  ) {
     setBirds((prev) =>
       prev.map((b, i) => (i === index ? { ...b, [field]: value } : b)),
     );
@@ -78,7 +82,7 @@ export default function EventForm({ initialData }: Props) {
     setBirds((prev) => prev.filter((_, i) => i !== index));
   }
 
-  function handleSubmit(e: React.FormEvent) {
+  function handleSubmit(e: React.SubmitEvent) {
     e.preventDefault();
     setError("");
     setSaving(true);
@@ -200,7 +204,10 @@ export default function EventForm({ initialData }: Props) {
                 />
               </div>
               <div className={styles.field}>
-                <label htmlFor={`bird-species-${index}`} className={styles.label}>
+                <label
+                  htmlFor={`bird-species-${index}`}
+                  className={styles.label}
+                >
                   Species
                 </label>
                 <input
@@ -214,14 +221,19 @@ export default function EventForm({ initialData }: Props) {
                 />
               </div>
               <div className={styles.field}>
-                <label htmlFor={`bird-location-${index}`} className={styles.label}>
+                <label
+                  htmlFor={`bird-location-${index}`}
+                  className={styles.label}
+                >
                   Location Name
                 </label>
                 <input
                   id={`bird-location-${index}`}
                   type="text"
                   value={bird.locationName}
-                  onChange={(e) => updateBird(index, "locationName", e.target.value)}
+                  onChange={(e) =>
+                    updateBird(index, "locationName", e.target.value)
+                  }
                   className={styles.input}
                   placeholder="e.g. Central Park, NY"
                   required
@@ -235,7 +247,9 @@ export default function EventForm({ initialData }: Props) {
                   id={`bird-date-${index}`}
                   type="date"
                   value={bird.dateStamp}
-                  onChange={(e) => updateBird(index, "dateStamp", e.target.value)}
+                  onChange={(e) =>
+                    updateBird(index, "dateStamp", e.target.value)
+                  }
                   className={styles.input}
                   required
                 />

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, startTransition } from "react";
 import { useRouter } from "next/navigation";
 import styles from "./EventForm.module.css";
 import BirdChatWidget from "./BirdChatWidget";
+import type { BirdingEvent, BirdEntry } from "@/db/schema";
 
-interface BirdEntry {
+interface BirdFormEntry {
   type: string;
   species: string;
   locationName: string;
@@ -15,7 +16,16 @@ interface BirdEntry {
   notes: string;
 }
 
-function emptyBird(): BirdEntry {
+interface InitialData {
+  event: BirdingEvent;
+  birds: BirdEntry[];
+}
+
+interface Props {
+  initialData?: InitialData;
+}
+
+function emptyBird(): BirdFormEntry {
   return {
     type: "",
     species: "",
@@ -27,16 +37,34 @@ function emptyBird(): BirdEntry {
   };
 }
 
-export default function EventForm() {
+function toBirdFormEntry(b: BirdEntry): BirdFormEntry {
+  return {
+    type: b.type,
+    species: b.species,
+    locationName: b.locationName,
+    lat: b.lat != null ? String(b.lat) : "",
+    lng: b.lng != null ? String(b.lng) : "",
+    dateStamp: b.dateStamp,
+    notes: b.notes ?? "",
+  };
+}
+
+export default function EventForm({ initialData }: Props) {
   const router = useRouter();
-  const [title, setTitle] = useState("");
-  const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
-  const [notes, setNotes] = useState("");
-  const [birds, setBirds] = useState<BirdEntry[]>([emptyBird()]);
+  const isEdit = !!initialData;
+
+  const [title, setTitle] = useState(initialData?.event.title ?? "");
+  const [date, setDate] = useState(
+    initialData?.event.date ?? new Date().toISOString().slice(0, 10),
+  );
+  const [notes, setNotes] = useState(initialData?.event.notes ?? "");
+  const [birds, setBirds] = useState<BirdFormEntry[]>(
+    initialData ? initialData.birds.map(toBirdFormEntry) : [],
+  );
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
 
-  function updateBird(index: number, field: keyof BirdEntry, value: string) {
+  function updateBird(index: number, field: keyof BirdFormEntry, value: string) {
     setBirds((prev) =>
       prev.map((b, i) => (i === index ? { ...b, [field]: value } : b)),
     );
@@ -50,7 +78,7 @@ export default function EventForm() {
     setBirds((prev) => prev.filter((_, i) => i !== index));
   }
 
-  async function handleSubmit(e: React.SubmitEvent) {
+  function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
     setSaving(true);
@@ -68,20 +96,25 @@ export default function EventForm() {
         })),
     };
 
-    const res = await fetch("/api/events", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(payload),
+    const url = isEdit ? `/api/events/${initialData!.event.id}` : "/api/events";
+    const method = isEdit ? "PUT" : "POST";
+
+    startTransition(async () => {
+      const res = await fetch(url, {
+        method,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      setSaving(false);
+
+      if (res.ok) {
+        router.push("/dashboard");
+        router.refresh();
+      } else {
+        setError("Failed to save event. Please try again.");
+      }
     });
-
-    setSaving(false);
-
-    if (res.ok) {
-      router.push("/dashboard");
-      router.refresh();
-    } else {
-      setError("Failed to save event. Please try again.");
-    }
   }
 
   return (
@@ -136,15 +169,13 @@ export default function EventForm() {
           <div key={index} className={styles.birdCard}>
             <div className={styles.birdCardHeader}>
               <span className={styles.birdIndex}>Bird #{index + 1}</span>
-              {birds.length > 1 && (
-                <button
-                  type="button"
-                  onClick={() => removeBird(index)}
-                  className={styles.removeBtn}
-                >
-                  Remove
-                </button>
-              )}
+              <button
+                type="button"
+                onClick={() => removeBird(index)}
+                className={styles.removeBtn}
+              >
+                Remove
+              </button>
             </div>
             <BirdChatWidget
               onIdentified={({ type, species, summary }) => {
@@ -169,10 +200,7 @@ export default function EventForm() {
                 />
               </div>
               <div className={styles.field}>
-                <label
-                  htmlFor={`bird-species-${index}`}
-                  className={styles.label}
-                >
+                <label htmlFor={`bird-species-${index}`} className={styles.label}>
                   Species
                 </label>
                 <input
@@ -186,19 +214,14 @@ export default function EventForm() {
                 />
               </div>
               <div className={styles.field}>
-                <label
-                  htmlFor={`bird-location-${index}`}
-                  className={styles.label}
-                >
+                <label htmlFor={`bird-location-${index}`} className={styles.label}>
                   Location Name
                 </label>
                 <input
                   id={`bird-location-${index}`}
                   type="text"
                   value={bird.locationName}
-                  onChange={(e) =>
-                    updateBird(index, "locationName", e.target.value)
-                  }
+                  onChange={(e) => updateBird(index, "locationName", e.target.value)}
                   className={styles.input}
                   placeholder="e.g. Central Park, NY"
                   required
@@ -212,9 +235,7 @@ export default function EventForm() {
                   id={`bird-date-${index}`}
                   type="date"
                   value={bird.dateStamp}
-                  onChange={(e) =>
-                    updateBird(index, "dateStamp", e.target.value)
-                  }
+                  onChange={(e) => updateBird(index, "dateStamp", e.target.value)}
                   className={styles.input}
                   required
                 />
@@ -265,7 +286,7 @@ export default function EventForm() {
         ))}
 
         <button type="button" onClick={addBird} className={styles.addBirdBtn}>
-          + Add Another Bird
+          + Add Bird
         </button>
       </section>
 
@@ -280,7 +301,7 @@ export default function EventForm() {
           Cancel
         </button>
         <button type="submit" disabled={saving} className={styles.saveBtn}>
-          {saving ? "Saving…" : "Save Event"}
+          {saving ? "Saving…" : isEdit ? "Save Changes" : "Save Event"}
         </button>
       </div>
     </form>

--- a/src/lib/dal/events.ts
+++ b/src/lib/dal/events.ts
@@ -1,0 +1,48 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "@/db";
+import { birdingEvents, birdEntries } from "@/db/schema";
+import type { BirdingEvent, BirdEntry } from "@/db/schema";
+
+export type EventWithBirds = BirdingEvent & { birds: BirdEntry[] };
+
+/** Fetch all events with their bird entries for a given user. */
+export async function getUserEvents(userId: string): Promise<EventWithBirds[]> {
+  const events = await db
+    .select()
+    .from(birdingEvents)
+    .where(eq(birdingEvents.userId, userId))
+    .orderBy(birdingEvents.date);
+
+  const birds = await db
+    .select()
+    .from(birdEntries)
+    .innerJoin(birdingEvents, eq(birdEntries.eventId, birdingEvents.id))
+    .where(eq(birdingEvents.userId, userId));
+
+  return events.map((event) => ({
+    ...event,
+    birds: birds
+      .filter((row) => row.bird_entries.eventId === event.id)
+      .map((row) => row.bird_entries),
+  }));
+}
+
+/** Fetch a single event with its birds, enforcing user ownership. Returns null if not found or not owned. */
+export async function getEventWithBirds(
+  eventId: number,
+  userId: string,
+): Promise<EventWithBirds | null> {
+  const [event] = await db
+    .select()
+    .from(birdingEvents)
+    .where(and(eq(birdingEvents.id, eventId), eq(birdingEvents.userId, userId)));
+
+  if (!event) return null;
+
+  const birds = await db
+    .select()
+    .from(birdEntries)
+    .where(eq(birdEntries.eventId, eventId));
+
+  return { ...event, birds };
+}


### PR DESCRIPTION
## Summary

- Create event without requiring bird sightings (birds now optional, form starts empty)
- Add birds to an existing event from the dashboard via `/events/[id]/add-bird`
- Edit events and their bird sightings via `/events/[id]/edit` (reuses `EventForm` with `initialData` prop)
- Delete events and individual bird sightings from all dashboard views (Timeline, Species, Location) with a confirmation dialog
- New DAL layer (`src/lib/dal/events.ts`) that also fixes a security bug where all users' bird entries were fetched without filtering by `userId`

## Key decisions

- `EventForm` refactored to accept optional `initialData` — drives both create (POST) and edit (PUT) flows
- PUT `/api/events/[id]` wrapped in a Drizzle transaction to prevent partial updates on failure
- DELETE `/api/birds/[id]` uses a single joined query for ownership enforcement (eliminates TOCTOU window)
- `ConfirmDialog` built with native `<dialog>` element and CSS Modules — no external libraries
- `EventActions` and `BirdActions` are separate client components to keep `DashboardTabs` clean
- Color scheme corrected throughout: purple `#753991` for submit buttons, blue `#209dd7` for accents

## Test plan

- [ ] Create a new event with no bird sightings — verify it saves and appears on dashboard
- [ ] Click "+ Add Bird" on an event card — verify navigates to add-bird page and bird is added
- [ ] Click "Edit" on an event card — verify navigates to edit page with pre-populated fields, save updates the event
- [ ] Delete an event from the dashboard — verify confirmation dialog appears, event and its birds are removed
- [ ] Delete a single bird sighting from Timeline, Species, and Location views — verify only that sighting is removed
- [ ] Verify all 17 unit tests pass: `pnpm test`
- [ ] Verify TypeScript is clean: `pnpm tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)