### PR TITLE
fix(BRD-16): center Confirm Dialog on screen

### DIFF
--- a/.claude/commands/implement-jira-issue.md
+++ b/.claude/commands/implement-jira-issue.md
@@ -6,9 +6,10 @@ description: command used to instruct Claude Code to run the /feature-dev comman
 run the /feature-dev plugin with the below instructions. Make sure to not skip any steps in the feature-dev process.
 
 <instructions>
--Implement Jira issue $1.
+-Implement Jira issue $1.  Use all the subtask work items as an implementation guide.
 -Create a new branch before implementation.
 -Update the Jira issue $1 status to IN PROGRESS.
+-Update each subtask to Done when the task has been finished.
 -Test and verify tests pass and raise a PR when completed.
 -<optional_human-input> $2 </optional_human-input>
 -DO NOT mark jira issue as done. Human will manually verify.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,10 @@ Renamed `vitest.config.ts` to `vitest.config.mts` to force ESM loading. Root cau
 
 Events can now be created without bird sightings (birds optional, form starts empty). Dashboard cards have Edit, Delete, and Add Bird actions on all three views (Timeline, Species, Location). Edit navigates to `/events/[id]/edit`, Add Bird to `/events/[id]/add-bird`. Delete uses a CSS-modules confirmation dialog. Individual bird sightings can also be deleted. New DAL layer (`src/lib/dal/events.ts`) fixes a security bug where all users' birds were fetched. PUT is wrapped in a Drizzle transaction for atomicity.
 
+### BRD-16 - Fix Dialog UI Issues (complete, PR #11)
+
+Added `position: static` to `.dialog` in `ConfirmDialog.module.css`. Root cause: HTML `<dialog>` defaults to `position: absolute`, bypassing the backdrop's flexbox centering and rendering the dialog at the far left. The fix makes it participate in flex layout and center correctly on screen.
+
 ### BRD-3 - Better Auth (complete, PR #4)
 
 Replaced mock auth with Better Auth. Email/password + Google OAuth. New /signup page. DB schema updated with Better Auth tables. Startup migration via scripts/migrate.ts.

--- a/src/components/ConfirmDialog.module.css
+++ b/src/components/ConfirmDialog.module.css
@@ -9,6 +9,7 @@
 }
 
 .dialog {
+  position: static;
   border: none;
   border-radius: 8px;
   padding: 1.5rem;


### PR DESCRIPTION
## Summary
- Root cause: HTML `<dialog>` element defaults to `position: absolute`, bypassing the backdrop's flexbox centering and causing the dialog to appear at the far left
- Fix: Added `position: static` to `.dialog` in `ConfirmDialog.module.css` so it participates in the flex layout and centers correctly
- Affects both delete confirmation dialogs (event delete and bird sighting delete)

## Test plan
- [ ] All 17 unit tests pass (`pnpm test`)
- [ ] Confirm Dialog appears centered on screen when deleting an event
- [ ] Confirm Dialog appears centered on screen when deleting a bird sighting

Closes BRD-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)