### PR TITLE
feat(BRD-21): improve bird record UX with view/edit and conditional AI chat

### DIFF
--- a/.claude/commands/complete-jira-issue.md
+++ b/.claude/commands/complete-jira-issue.md
@@ -4,6 +4,6 @@ description: Command used to mark the jira issue complete and update the AGENTS.
 ---
 
 <instruction>
-update the jira issue $1 to completed. Then update the @AGENTS.md with a brief and concise summary status update in the  
+update the jira issue $1 to Done. Then update the @AGENTS.md with a brief and concise summary status update in the  
  Implementation Status section.
 </instruction>

--- a/.claude/commands/implement-jira-issue.md
+++ b/.claude/commands/implement-jira-issue.md
@@ -12,5 +12,5 @@ run the /feature-dev plugin with the below instructions. Make sure to not skip a
 -Update each subtask to Done when the task has been finished.
 -Test and verify tests pass and raise a PR when completed.
 -<optional_human-input> $2 </optional_human-input>
--DO NOT mark jira issue as done. Human will manually verify.
+-DO NOT mark jira issue as done until you are told specifically. Human will manually verify.
 </instructions>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ Events can now be created without bird sightings (birds optional, form starts em
 
 Added `position: static` to `.dialog` in `ConfirmDialog.module.css`. Root cause: HTML `<dialog>` defaults to `position: absolute`, bypassing the backdrop's flexbox centering and rendering the dialog at the far left. The fix makes it participate in flex layout and center correctly on screen.
 
+### BRD-21 - Improve Bird Record UX (complete, PR #12)
+
+View button added to each bird record card on the dashboard (next to Delete), linking to `/birds/[id]/edit`. New server-authenticated `/birds/[id]/edit` page with `BirdEditForm` client component for viewing and updating all sighting fields (no AI chat). `PUT /api/birds/[id]` route added with ownership verification and required-field validation. `getBirdEntry` DAL function added with user ownership enforcement. `BirdChatWidget` hidden in `EventForm` when editing (`{!isEdit && ...}`).
+
 ### BRD-3 - Better Auth (complete, PR #4)
 
 Replaced mock auth with Better Auth. Email/password + Google OAuth. New /signup page. DB schema updated with Better Auth tables. Startup migration via scripts/migrate.ts.

--- a/src/app/api/birds/[id]/route.ts
+++ b/src/app/api/birds/[id]/route.ts
@@ -4,6 +4,41 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { birdingEvents, birdEntries } from "@/db/schema";
 
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const birdId = parseInt(id, 10);
+  if (isNaN(birdId)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
+
+  // Verify ownership
+  const [row] = await db
+    .select({ birdId: birdEntries.id })
+    .from(birdEntries)
+    .innerJoin(birdingEvents, eq(birdEntries.eventId, birdingEvents.id))
+    .where(and(eq(birdEntries.id, birdId), eq(birdingEvents.userId, session.user.id)));
+
+  if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json();
+  const { type, species, locationName, lat, lng, dateStamp, notes } = body;
+
+  if (!type || !species || !locationName || !dateStamp) {
+    return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
+  }
+
+  await db
+    .update(birdEntries)
+    .set({ type, species, locationName, lat: lat ?? null, lng: lng ?? null, dateStamp, notes: notes ?? null })
+    .where(eq(birdEntries.id, birdId));
+
+  return NextResponse.json({ ok: true });
+}
+
 export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },

--- a/src/app/birds/[id]/edit/page.module.css
+++ b/src/app/birds/[id]/edit/page.module.css
@@ -1,0 +1,34 @@
+.page {
+  min-height: 100vh;
+}
+
+.header {
+  background: white;
+  border-bottom: 1px solid #e8e8e4;
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: #209dd7;
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #032147;
+}
+
+.main {
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}

--- a/src/app/birds/[id]/edit/page.tsx
+++ b/src/app/birds/[id]/edit/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+import { requireAuth } from "@/lib/session";
+import { getBirdEntry } from "@/lib/dal/events";
+import BirdEditForm from "@/components/BirdEditForm";
+import Link from "next/link";
+import styles from "./page.module.css";
+
+export default async function BirdEditPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await requireAuth();
+  const { id } = await params;
+  const birdId = parseInt(id, 10);
+
+  if (isNaN(birdId)) notFound();
+
+  const bird = await getBirdEntry(birdId, session.user.id);
+  if (!bird) notFound();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard" className={styles.back}>
+          ← Back to Dashboard
+        </Link>
+        <h1 className={styles.title}>Edit Bird Sighting</h1>
+      </header>
+      <main className={styles.main}>
+        <BirdEditForm bird={bird} />
+      </main>
+    </div>
+  );
+}

--- a/src/components/BirdActions.module.css
+++ b/src/components/BirdActions.module.css
@@ -1,3 +1,21 @@
+.viewBtn {
+  padding: 0.2rem 0.5rem;
+  border: 1px solid #209dd7;
+  border-radius: 4px;
+  background: white;
+  color: #209dd7;
+  font-size: 0.75rem;
+  cursor: pointer;
+  flex-shrink: 0;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.viewBtn:hover {
+  background: #209dd7;
+  color: white;
+}
+
 .deleteBtn {
   padding: 0.2rem 0.5rem;
   border: 1px solid #c0392b;

--- a/src/components/BirdActions.tsx
+++ b/src/components/BirdActions.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import ConfirmDialog from "./ConfirmDialog";
 import styles from "./BirdActions.module.css";
 
@@ -28,6 +29,9 @@ export default function BirdActions({ birdId, birdSpecies }: Props) {
 
   return (
     <>
+      <Link href={`/birds/${birdId}/edit`} className={styles.viewBtn}>
+        View
+      </Link>
       <button
         type="button"
         onClick={() => setConfirming(true)}

--- a/src/components/BirdEditForm.module.css
+++ b/src/components/BirdEditForm.module.css
@@ -1,0 +1,107 @@
+.form {
+  background: white;
+  border-radius: 10px;
+  padding: 1.5rem;
+  border: 1px solid #e8e8e4;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+@media (max-width: 540px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.input {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.15s;
+}
+
+.input:focus {
+  outline: none;
+  border-color: #209dd7;
+}
+
+.textarea {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  resize: vertical;
+  transition: border-color 0.15s;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: #209dd7;
+}
+
+.error {
+  color: #c0392b;
+  font-size: 0.875rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-top: 0.5rem;
+}
+
+.cancelBtn {
+  background: none;
+  border: 1px solid #ddd;
+  padding: 0.6rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: #555;
+  cursor: pointer;
+}
+
+.cancelBtn:hover {
+  background: #f0f0ea;
+}
+
+.saveBtn {
+  background: #753991;
+  color: white;
+  border: none;
+  padding: 0.6rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.saveBtn:hover:not(:disabled) {
+  background: #5e2e74;
+}
+
+.saveBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/components/BirdEditForm.tsx
+++ b/src/components/BirdEditForm.tsx
@@ -1,0 +1,173 @@
+"use client";
+
+import { useState, startTransition } from "react";
+import { useRouter } from "next/navigation";
+import type { BirdEntry } from "@/db/schema";
+import styles from "./BirdEditForm.module.css";
+
+interface Props {
+  bird: BirdEntry;
+}
+
+export default function BirdEditForm({ bird }: Props) {
+  const router = useRouter();
+  const [type, setType] = useState(bird.type);
+  const [species, setSpecies] = useState(bird.species);
+  const [locationName, setLocationName] = useState(bird.locationName);
+  const [lat, setLat] = useState(bird.lat != null ? String(bird.lat) : "");
+  const [lng, setLng] = useState(bird.lng != null ? String(bird.lng) : "");
+  const [dateStamp, setDateStamp] = useState(bird.dateStamp);
+  const [notes, setNotes] = useState(bird.notes ?? "");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  function handleSubmit(e: React.SubmitEvent) {
+    e.preventDefault();
+    setError("");
+    setSaving(true);
+
+    startTransition(async () => {
+      const res = await fetch(`/api/birds/${bird.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type,
+          species,
+          locationName,
+          lat: lat !== "" ? parseFloat(lat) : null,
+          lng: lng !== "" ? parseFloat(lng) : null,
+          dateStamp,
+          notes,
+        }),
+      });
+
+      setSaving(false);
+
+      if (res.ok) {
+        router.push("/dashboard");
+        router.refresh();
+      } else {
+        setError("Failed to save changes. Please try again.");
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <div className={styles.grid}>
+        <div className={styles.field}>
+          <label htmlFor="type" className={styles.label}>
+            Type
+          </label>
+          <input
+            id="type"
+            type="text"
+            value={type}
+            onChange={(e) => setType(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. Raptor"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="species" className={styles.label}>
+            Species
+          </label>
+          <input
+            id="species"
+            type="text"
+            value={species}
+            onChange={(e) => setSpecies(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. Red-tailed Hawk"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="locationName" className={styles.label}>
+            Location Name
+          </label>
+          <input
+            id="locationName"
+            type="text"
+            value={locationName}
+            onChange={(e) => setLocationName(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. Central Park, NY"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="dateStamp" className={styles.label}>
+            Date Observed
+          </label>
+          <input
+            id="dateStamp"
+            type="date"
+            value={dateStamp}
+            onChange={(e) => setDateStamp(e.target.value)}
+            className={styles.input}
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="lat" className={styles.label}>
+            Latitude (optional)
+          </label>
+          <input
+            id="lat"
+            type="number"
+            step="any"
+            value={lat}
+            onChange={(e) => setLat(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. 40.7851"
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="lng" className={styles.label}>
+            Longitude (optional)
+          </label>
+          <input
+            id="lng"
+            type="number"
+            step="any"
+            value={lng}
+            onChange={(e) => setLng(e.target.value)}
+            className={styles.input}
+            placeholder="e.g. -73.9683"
+          />
+        </div>
+      </div>
+
+      <div className={styles.field}>
+        <label htmlFor="notes" className={styles.label}>
+          Notes
+        </label>
+        <textarea
+          id="notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className={styles.textarea}
+          rows={3}
+          placeholder="Optional notes about this sighting"
+        />
+      </div>
+
+      {error && <p className={styles.error}>{error}</p>}
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          onClick={() => router.push("/dashboard")}
+          className={styles.cancelBtn}
+        >
+          Cancel
+        </button>
+        <button type="submit" disabled={saving} className={styles.saveBtn}>
+          {saving ? "Saving…" : "Save Changes"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -181,13 +181,15 @@ export default function EventForm({ initialData }: Props) {
                 Remove
               </button>
             </div>
-            <BirdChatWidget
-              onIdentified={({ type, species, summary }) => {
-                updateBird(index, "type", type);
-                updateBird(index, "species", species);
-                if (summary) updateBird(index, "notes", summary);
-              }}
-            />
+            {!isEdit && (
+              <BirdChatWidget
+                onIdentified={({ type, species, summary }) => {
+                  updateBird(index, "type", type);
+                  updateBird(index, "species", species);
+                  if (summary) updateBird(index, "notes", summary);
+                }}
+              />
+            )}
             <div className={styles.birdGrid}>
               <div className={styles.field}>
                 <label htmlFor={`bird-type-${index}`} className={styles.label}>

--- a/src/lib/dal/events.ts
+++ b/src/lib/dal/events.ts
@@ -27,6 +27,20 @@ export async function getUserEvents(userId: string): Promise<EventWithBirds[]> {
   }));
 }
 
+/** Fetch a single bird entry, enforcing user ownership via the parent event. Returns null if not found or not owned. */
+export async function getBirdEntry(
+  birdId: number,
+  userId: string,
+): Promise<BirdEntry | null> {
+  const [row] = await db
+    .select({ bird: birdEntries })
+    .from(birdEntries)
+    .innerJoin(birdingEvents, eq(birdEntries.eventId, birdingEvents.id))
+    .where(and(eq(birdEntries.id, birdId), eq(birdingEvents.userId, userId)));
+
+  return row?.bird ?? null;
+}
+
 /** Fetch a single event with its birds, enforcing user ownership. Returns null if not found or not owned. */
 export async function getEventWithBirds(
   eventId: number,

--- a/src/tests/unit/birdEdit.test.ts
+++ b/src/tests/unit/birdEdit.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+
+/** Mirrors the payload-building logic in BirdEditForm and AddBirdForm */
+function buildBirdPayload(fields: {
+  type: string;
+  species: string;
+  locationName: string;
+  lat: string;
+  lng: string;
+  dateStamp: string;
+  notes: string;
+}) {
+  return {
+    type: fields.type,
+    species: fields.species,
+    locationName: fields.locationName,
+    lat: fields.lat !== "" ? parseFloat(fields.lat) : null,
+    lng: fields.lng !== "" ? parseFloat(fields.lng) : null,
+    dateStamp: fields.dateStamp,
+    notes: fields.notes,
+  };
+}
+
+describe("buildBirdPayload", () => {
+  it("converts numeric lat/lng strings to floats", () => {
+    const payload = buildBirdPayload({
+      type: "Raptor",
+      species: "Osprey",
+      locationName: "Lake View",
+      lat: "40.7851",
+      lng: "-73.9683",
+      dateStamp: "2025-03-01",
+      notes: "Seen near water",
+    });
+    expect(payload.lat).toBe(40.7851);
+    expect(payload.lng).toBe(-73.9683);
+  });
+
+  it("sets lat/lng to null when empty strings", () => {
+    const payload = buildBirdPayload({
+      type: "Songbird",
+      species: "Robin",
+      locationName: "Park",
+      lat: "",
+      lng: "",
+      dateStamp: "2025-03-01",
+      notes: "",
+    });
+    expect(payload.lat).toBeNull();
+    expect(payload.lng).toBeNull();
+  });
+
+  it("preserves all string fields unchanged", () => {
+    const payload = buildBirdPayload({
+      type: "Waterfowl",
+      species: "Mallard",
+      locationName: "River Bend",
+      lat: "",
+      lng: "",
+      dateStamp: "2025-06-15",
+      notes: "Near the reeds",
+    });
+    expect(payload.type).toBe("Waterfowl");
+    expect(payload.species).toBe("Mallard");
+    expect(payload.locationName).toBe("River Bend");
+    expect(payload.dateStamp).toBe("2025-06-15");
+    expect(payload.notes).toBe("Near the reeds");
+  });
+});


### PR DESCRIPTION
## Summary

- Add **View button** to each bird record on the dashboard (next to Delete), linking to `/birds/[id]/edit`
- New `/birds/[id]/edit` server page with `BirdEditForm` client component for viewing and updating bird sighting fields
- Add `PUT /api/birds/[id]` route with ownership verification and required-field validation
- Add `getBirdEntry` DAL function with user ownership enforcement via inner join
- Hide `BirdChatWidget` in `EventForm` when editing an existing event (`{!isEdit && <BirdChatWidget />}`)

## Test plan

- [ ] All 20 unit tests pass (`pnpm test`)
- [ ] TypeScript compiles clean (`pnpm tsc --noEmit`)
- [ ] View button appears on each bird card on the dashboard
- [ ] View button navigates to `/birds/[id]/edit` and pre-populates all fields
- [ ] Saving changes on the edit page updates the bird and redirects to dashboard
- [ ] AI chat is visible when adding a new bird sighting (create mode)
- [ ] AI chat is hidden when editing an existing event's bird cards

Closes BRD-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)