### PR TITLE
feat(BRD-15): bird identification by photo upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@
 *.db-shm
 *.db-wal
 
+# uploaded photos
+/uploads
+
 # next.js
 /.next/
 /out/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,10 @@ Edit link added to each bird sighting card on the event edit page, navigating to
 
 "Use my location" button added to `AddBirdForm` — calls browser Geolocation API and autofills lat/lng only when fields are blank; does not trigger on edit. In the dashboard Location tab, a Map button (dark green, `#2c6e49`) is conditionally shown per bird record when coordinates are present; clicking it opens an embedded OpenStreetMap iframe in an in-app `MapDialog` dialog. New `MapDialog` component and 8 unit tests added (33 total passing).
 
+### BRD-15 - Bird Identification by Photo (complete, PR #15)
+
+Photo upload added to `AddBirdForm` and `BirdEditForm`. `POST /api/uploads` saves files to filesystem (`UPLOAD_DIR` env, default `./uploads/`); `GET /api/uploads/[filename]` serves them with canonical path check and `nosniff` headers. `POST /api/identify-photo` base64-encodes the image and sends it to `openai/gpt-4o` via OpenRouter, parsing the response with `parseIdentification`. On success the chat widget is hidden and type/species/notes are auto-populated. `photo_path` nullable column added to `bird_entries` via migration `0002_add_photo_path.sql`. All 3 dashboard views show a 48px inline thumbnail or a "No Photo" placeholder. 7 new unit tests (40 total).
+
 ### BRD-3 - Better Auth (complete, PR #4)
 
 Replaced mock auth with Better Auth. Email/password + Google OAuth. New /signup page. DB schema updated with Better Auth tables. Startup migration via scripts/migrate.ts.

--- a/drizzle/0002_add_photo_path.sql
+++ b/drizzle/0002_add_photo_path.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `bird_entries` ADD COLUMN `photo_path` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1773145256211,
       "tag": "0001_white_firebrand",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1742000000000,
+      "tag": "0002_add_photo_path",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/birds/[id]/route.ts
+++ b/src/app/api/birds/[id]/route.ts
@@ -3,6 +3,7 @@ import { eq, and } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { birdingEvents, birdEntries } from "@/db/schema";
+import { isSafeFilename } from "@/lib/uploads";
 
 export async function PUT(
   req: NextRequest,
@@ -25,15 +26,19 @@ export async function PUT(
   if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   const body = await req.json();
-  const { type, species, locationName, lat, lng, dateStamp, notes } = body;
+  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath } = body;
 
   if (!type || !species || !locationName || !dateStamp) {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }
 
+  if (photoPath && !isSafeFilename(photoPath)) {
+    return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
+  }
+
   await db
     .update(birdEntries)
-    .set({ type, species, locationName, lat: lat ?? null, lng: lng ?? null, dateStamp, notes: notes ?? null })
+    .set({ type, species, locationName, lat: lat ?? null, lng: lng ?? null, dateStamp, notes: notes ?? null, photoPath: photoPath ?? null })
     .where(eq(birdEntries.id, birdId));
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/events/[id]/birds/route.ts
+++ b/src/app/api/events/[id]/birds/route.ts
@@ -22,7 +22,7 @@ export async function POST(
 
   if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const { type, species, locationName, lat, lng, dateStamp, notes } = await req.json();
+  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath } = await req.json();
 
   const [bird] = await db
     .insert(birdEntries)
@@ -35,6 +35,7 @@ export async function POST(
       lng: lng ?? null,
       dateStamp,
       notes: notes ?? null,
+      photoPath: photoPath ?? null,
     })
     .returning();
 

--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import OpenAI from "openai";
+import fs from "fs/promises";
+import path from "path";
+import { auth } from "@/lib/auth";
+import { getUploadPath, isSafeFilename } from "@/lib/uploads";
+import { parseIdentification } from "@/lib/chat";
+
+const VISION_MODEL = "openai/gpt-4o";
+
+const IDENTIFY_PROMPT =
+  "You are an expert ornithologist. Identify the bird in this photo. " +
+  "Provide: bird type (e.g. Raptor, Songbird), species (common name), " +
+  "and a brief summary under 200 words covering appearance, habitat, and behaviour. " +
+  'End with exactly: {"identified": true, "type": "...", "species": "..."}';
+
+function getClient() {
+  return new OpenAI({
+    apiKey: process.env.OPENROUTER_API_KEY,
+    baseURL: "https://openrouter.ai/api/v1",
+    defaultHeaders: {
+      "HTTP-Referer": process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+      "X-Title": "Bird Cage",
+    },
+  });
+}
+
+export async function POST(req: NextRequest) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { photoPath } = (await req.json()) as { photoPath: string };
+
+  if (!photoPath || !isSafeFilename(photoPath)) {
+    return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
+  }
+
+  const filePath = getUploadPath(photoPath);
+  let buffer: Buffer;
+  try {
+    buffer = await fs.readFile(filePath);
+  } catch {
+    return NextResponse.json({ error: "Photo not found" }, { status: 404 });
+  }
+
+  const ext = path.extname(photoPath).toLowerCase().replace(".", "");
+  const mimeType = ext === "jpg" ? "image/jpeg" : `image/${ext}`;
+  const dataUrl = `data:${mimeType};base64,${buffer.toString("base64")}`;
+
+  const client = getClient();
+
+  let responseText: string;
+  try {
+    const completion = await client.chat.completions.create({
+      model: VISION_MODEL,
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "image_url", image_url: { url: dataUrl } },
+            { type: "text", text: IDENTIFY_PROMPT },
+          ],
+        },
+      ],
+    });
+    responseText = completion.choices[0]?.message?.content ?? "";
+  } catch (err) {
+    const message = (err as { message?: string }).message ?? "AI request failed";
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const result = parseIdentification(responseText);
+  if (!result) {
+    return NextResponse.json({ error: "Could not identify bird from photo" }, { status: 422 });
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/uploads/[filename]/route.ts
+++ b/src/app/api/uploads/[filename]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs/promises";
+import path from "path";
+import { auth } from "@/lib/auth";
+import { getUploadDir, getUploadPath, isSafeFilename } from "@/lib/uploads";
+
+const MIME_MAP: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ filename: string }> },
+) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return new Response("Unauthorized", { status: 401 });
+
+  const { filename } = await params;
+
+  if (!isSafeFilename(filename)) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const filePath = getUploadPath(filename);
+
+  // Canonical path check — reject any path that escapes the upload directory
+  const resolvedFile = path.resolve(filePath);
+  const resolvedDir = path.resolve(getUploadDir());
+  if (!resolvedFile.startsWith(resolvedDir + path.sep)) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  let buffer: Buffer;
+  try {
+    buffer = await fs.readFile(filePath);
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+
+  const ext = path.extname(filename).toLowerCase();
+  const contentType = MIME_MAP[ext] ?? "application/octet-stream";
+
+  return new Response(buffer.buffer as ArrayBuffer, {
+    headers: {
+      "Content-Type": contentType,
+      "X-Content-Type-Options": "nosniff",
+      "Content-Disposition": "inline",
+    },
+  });
+}

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { auth } from "@/lib/auth";
+import { getUploadDir } from "@/lib/uploads";
+
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_EXTS = new Set([".jpg", ".jpeg", ".png", ".gif", ".webp"]);
+
+export async function POST(req: NextRequest) {
+  const session = await auth.api.getSession({ headers: req.headers });
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const formData = await req.formData();
+  const file = formData.get("file");
+
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  if (!file.type.startsWith("image/")) {
+    return NextResponse.json({ error: "File must be an image" }, { status: 400 });
+  }
+
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json({ error: "File exceeds 5MB limit" }, { status: 413 });
+  }
+
+  const ext = path.extname(file.name).toLowerCase();
+  if (!ALLOWED_EXTS.has(ext)) {
+    return NextResponse.json({ error: "Unsupported file type" }, { status: 415 });
+  }
+  const filename = `${randomUUID()}${ext}`;
+  const buffer = Buffer.from(await file.arrayBuffer());
+
+  await fs.writeFile(path.join(getUploadDir(), filename), buffer);
+
+  return NextResponse.json({ path: filename });
+}

--- a/src/components/AddBirdForm.module.css
+++ b/src/components/AddBirdForm.module.css
@@ -137,3 +137,37 @@
   font-size: 0.8rem;
   color: #c0392b;
 }
+
+.photoSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.photoLabel {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.photoInput {
+  font-size: 0.9rem;
+}
+
+.photoStatus {
+  font-size: 0.82rem;
+  color: #209dd7;
+}
+
+.photoError {
+  font-size: 0.82rem;
+  color: #c0392b;
+}
+
+.photoThumb {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid #ddd;
+}

--- a/src/components/AddBirdForm.tsx
+++ b/src/components/AddBirdForm.tsx
@@ -24,6 +24,12 @@ export default function AddBirdForm({ eventId }: Props) {
   const [saving, setSaving] = useState(false);
   const [geoLoading, setGeoLoading] = useState(false);
   const [geoError, setGeoError] = useState("");
+  const [photoPath, setPhotoPath] = useState("");
+  const [photoPreview, setPhotoPreview] = useState("");
+  const [photoStatus, setPhotoStatus] = useState("");
+  const [photoError, setPhotoError] = useState("");
+  const [photoIdentified, setPhotoIdentified] = useState(false);
+  const [photoUploading, setPhotoUploading] = useState(false);
 
   function useMyLocation() {
     if (!navigator.geolocation) {
@@ -45,6 +51,59 @@ export default function AddBirdForm({ eventId }: Props) {
     );
   }
 
+  async function handlePhotoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setPhotoError("");
+    setPhotoStatus("Uploading photo...");
+    setPhotoUploading(true);
+    setPhotoPreview((prev) => {
+      if (prev.startsWith("blob:")) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
+
+    const form = new FormData();
+    form.append("file", file);
+
+    try {
+      const uploadRes = await fetch("/api/uploads", { method: "POST", body: form });
+      if (!uploadRes.ok) {
+        const body = await uploadRes.json().catch(() => ({}));
+        setPhotoError((body as { error?: string }).error ?? "Upload failed");
+        setPhotoStatus("");
+        return;
+      }
+
+      const { path: uploadedPath } = (await uploadRes.json()) as { path: string };
+      setPhotoPath(uploadedPath);
+      setPhotoStatus("Identifying bird from photo...");
+
+      const identRes = await fetch("/api/identify-photo", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ photoPath: uploadedPath }),
+      });
+
+      if (!identRes.ok) {
+        setPhotoStatus("Photo uploaded. Could not identify bird — please use the chat below.");
+        return;
+      }
+
+      const result = (await identRes.json()) as { type: string; species: string; summary: string };
+      setType(result.type);
+      setSpecies(result.species);
+      if (result.summary) setNotes(result.summary);
+      setPhotoIdentified(true);
+      setPhotoStatus("Bird identified from photo — fields populated.");
+    } catch {
+      setPhotoError("Something went wrong. Please try again.");
+      setPhotoStatus("");
+    } finally {
+      setPhotoUploading(false);
+    }
+  }
+
   function handleSubmit(e: React.SubmitEvent) {
     e.preventDefault();
     setError("");
@@ -62,6 +121,7 @@ export default function AddBirdForm({ eventId }: Props) {
           lng: lng !== "" ? parseFloat(lng) : null,
           dateStamp,
           notes,
+          photoPath: photoPath || null,
         }),
       });
 
@@ -78,13 +138,31 @@ export default function AddBirdForm({ eventId }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
-      <BirdChatWidget
-        onIdentified={({ type: t, species: s, summary }) => {
-          setType(t);
-          setSpecies(s);
-          if (summary) setNotes(summary);
-        }}
-      />
+      <div className={styles.photoSection}>
+        <label className={styles.photoLabel}>Photo (optional)</label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handlePhotoChange}
+          disabled={photoUploading}
+          className={styles.photoInput}
+        />
+        {photoPreview && (
+          <img src={photoPreview} alt="Preview" className={styles.photoThumb} />
+        )}
+        {photoStatus && <span className={styles.photoStatus}>{photoStatus}</span>}
+        {photoError && <span className={styles.photoError}>{photoError}</span>}
+      </div>
+
+      {!photoIdentified && (
+        <BirdChatWidget
+          onIdentified={({ type: t, species: s, summary }) => {
+            setType(t);
+            setSpecies(s);
+            if (summary) setNotes(summary);
+          }}
+        />
+      )}
 
       <div className={styles.grid}>
         <div className={styles.field}>

--- a/src/components/BirdEditForm.module.css
+++ b/src/components/BirdEditForm.module.css
@@ -105,3 +105,37 @@
   opacity: 0.6;
   cursor: not-allowed;
 }
+
+.photoSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.photoLabel {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: #555;
+}
+
+.photoInput {
+  font-size: 0.9rem;
+}
+
+.photoStatus {
+  font-size: 0.82rem;
+  color: #209dd7;
+}
+
+.photoError {
+  font-size: 0.82rem;
+  color: #c0392b;
+}
+
+.photoThumb {
+  width: 80px;
+  height: 80px;
+  object-fit: cover;
+  border-radius: 6px;
+  border: 1px solid #ddd;
+}

--- a/src/components/BirdEditForm.tsx
+++ b/src/components/BirdEditForm.tsx
@@ -21,6 +21,48 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
   const [notes, setNotes] = useState(bird.notes ?? "");
   const [error, setError] = useState("");
   const [saving, setSaving] = useState(false);
+  const [photoPath, setPhotoPath] = useState(bird.photoPath ?? "");
+  const [photoPreview, setPhotoPreview] = useState(
+    bird.photoPath ? `/api/uploads/${bird.photoPath}` : "",
+  );
+  const [photoStatus, setPhotoStatus] = useState("");
+  const [photoError, setPhotoError] = useState("");
+  const [photoUploading, setPhotoUploading] = useState(false);
+
+  async function handlePhotoChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setPhotoError("");
+    setPhotoStatus("Uploading photo...");
+    setPhotoUploading(true);
+    setPhotoPreview((prev) => {
+      if (prev.startsWith("blob:")) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(file);
+    });
+
+    const form = new FormData();
+    form.append("file", file);
+
+    try {
+      const res = await fetch("/api/uploads", { method: "POST", body: form });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setPhotoError((body as { error?: string }).error ?? "Upload failed");
+        setPhotoStatus("");
+        return;
+      }
+
+      const { path: uploadedPath } = (await res.json()) as { path: string };
+      setPhotoPath(uploadedPath);
+      setPhotoStatus("Photo uploaded.");
+    } catch {
+      setPhotoError("Something went wrong. Please try again.");
+      setPhotoStatus("");
+    } finally {
+      setPhotoUploading(false);
+    }
+  }
 
   function handleSubmit(e: React.SubmitEvent) {
     e.preventDefault();
@@ -39,6 +81,7 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
           lng: lng !== "" ? parseFloat(lng) : null,
           dateStamp,
           notes,
+          photoPath: photoPath || null,
         }),
       });
 
@@ -55,6 +98,22 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
+      <div className={styles.photoSection}>
+        <label className={styles.photoLabel}>Photo (optional)</label>
+        {photoPreview && (
+          <img src={photoPreview} alt="Bird photo" className={styles.photoThumb} />
+        )}
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handlePhotoChange}
+          disabled={photoUploading}
+          className={styles.photoInput}
+        />
+        {photoStatus && <span className={styles.photoStatus}>{photoStatus}</span>}
+        {photoError && <span className={styles.photoError}>{photoError}</span>}
+      </div>
+
       <div className={styles.grid}>
         <div className={styles.field}>
           <label htmlFor="type" className={styles.label}>

--- a/src/components/DashboardTabs.module.css
+++ b/src/components/DashboardTabs.module.css
@@ -143,3 +143,27 @@
   gap: 0.4rem;
   flex-shrink: 0;
 }
+
+.birdThumb {
+  width: 48px;
+  height: 48px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #e8e8e4;
+  flex-shrink: 0;
+}
+
+.noPhoto {
+  width: 48px;
+  height: 48px;
+  border-radius: 4px;
+  border: 1px solid #e8e8e4;
+  background: #f5f5f0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.55rem;
+  color: #aaa;
+  text-align: center;
+  flex-shrink: 0;
+}

--- a/src/components/DashboardTabs.tsx
+++ b/src/components/DashboardTabs.tsx
@@ -71,6 +71,9 @@ function TimelineView({ events }: { events: EventWithBirds[] }) {
             <ul className={styles.birdList}>
               {event.birds.map((bird) => (
                 <li key={bird.id} className={styles.birdItem}>
+                  {bird.photoPath
+                    ? <img src={`/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
+                    : <div className={styles.noPhoto}>No Photo</div>}
                   <div className={styles.birdItemInfo}>
                     <span className={styles.birdName}>{bird.species}</span>
                     <span className={styles.birdMeta}>{bird.type} · {bird.locationName}</span>
@@ -110,6 +113,9 @@ function SpeciesView({ events }: { events: EventWithBirds[] }) {
           <ul className={styles.birdList}>
             {entries.map(({ bird, eventTitle, eventDate }) => (
               <li key={bird.id} className={styles.birdItem}>
+                {bird.photoPath
+                  ? <img src={`/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
+                  : <div className={styles.noPhoto}>No Photo</div>}
                 <div className={styles.birdItemInfo}>
                   <span className={styles.birdName}>{eventTitle}</span>
                   <span className={styles.birdMeta}>{eventDate} · {bird.locationName}</span>
@@ -151,6 +157,9 @@ function LocationView({ events }: { events: EventWithBirds[] }) {
             <ul className={styles.birdList}>
               {entries.map(({ bird, eventTitle, eventDate }) => (
                 <li key={bird.id} className={styles.birdItem}>
+                  {bird.photoPath
+                    ? <img src={`/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
+                    : <div className={styles.noPhoto}>No Photo</div>}
                   <div className={styles.birdItemInfo}>
                     <span className={styles.birdName}>{bird.species} ({bird.type})</span>
                     <span className={styles.birdMeta}>{eventTitle} · {eventDate}</span>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -116,6 +116,7 @@ export const birdEntries = sqliteTable("bird_entries", {
   lng: real("lng"),
   dateStamp: text("date_stamp").notNull(),
   notes: text("notes"),
+  photoPath: text("photo_path"),
 });
 
 // Relations

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+/** Returns the upload directory, creating it if necessary. */
+export function getUploadDir(): string {
+  const dir = process.env.UPLOAD_DIR ?? path.join(process.cwd(), "uploads");
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** Returns the absolute path for a given filename inside the upload directory. */
+export function getUploadPath(filename: string): string {
+  return path.join(getUploadDir(), filename);
+}
+
+/** Returns true if the filename is safe (no path traversal). */
+export function isSafeFilename(filename: string): boolean {
+  return (
+    !filename.includes("/") &&
+    !filename.includes("\\") &&
+    !filename.includes("..")
+  );
+}

--- a/src/tests/unit/csv.test.ts
+++ b/src/tests/unit/csv.test.ts
@@ -21,6 +21,7 @@ const baseBird: BirdEntry = {
   lng: -73.9683,
   dateStamp: "2024-03-01",
   notes: "Spotted near the pond",
+  photoPath: null,
 };
 
 describe("generateCsv", () => {

--- a/src/tests/unit/photoIdentify.test.ts
+++ b/src/tests/unit/photoIdentify.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { parseIdentification } from "@/lib/chat";
+
+describe("parseIdentification - photo AI response shapes", () => {
+  it("parses a clean JSON block after a summary", () => {
+    const text =
+      "The Robin is a small passerine bird with an orange-red breast. " +
+      'It is common in gardens and woodland edges.\n{"identified": true, "type": "Songbird", "species": "European Robin"}';
+    const result = parseIdentification(text);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("Songbird");
+    expect(result?.species).toBe("European Robin");
+    expect(result?.summary).toContain("Robin");
+  });
+
+  it("parses JSON wrapped in markdown fences", () => {
+    const text =
+      "A large bird of prey commonly seen soaring over open countryside.\n" +
+      '```json\n{"identified": true, "type": "Raptor", "species": "Red Kite"}\n```';
+    const result = parseIdentification(text);
+    expect(result).not.toBeNull();
+    expect(result?.type).toBe("Raptor");
+    expect(result?.species).toBe("Red Kite");
+  });
+
+  it("returns null when identified is false", () => {
+    const text = 'I need more information. {"identified": false}';
+    expect(parseIdentification(text)).toBeNull();
+  });
+
+  it("returns null when JSON block is missing", () => {
+    const text = "This looks like a sparrow but I cannot be certain.";
+    expect(parseIdentification(text)).toBeNull();
+  });
+
+  it("returns null when type or species is missing from JSON", () => {
+    const text = 'A bird.\n{"identified": true, "type": "Songbird"}';
+    expect(parseIdentification(text)).toBeNull();
+  });
+
+  it("extracts summary as text before the JSON block", () => {
+    const summary = "The Barn Owl is a nocturnal hunter with a heart-shaped face.";
+    const text = `${summary}\n{"identified": true, "type": "Owl", "species": "Barn Owl"}`;
+    const result = parseIdentification(text);
+    expect(result?.summary).toContain("Barn Owl");
+  });
+
+  it("handles multiple JSON-like objects and picks the correct one", () => {
+    const text =
+      'The user mentioned {"color": "brown"}. Based on this: the bird is a Thrush.\n' +
+      '{"identified": true, "type": "Songbird", "species": "Song Thrush"}';
+    const result = parseIdentification(text);
+    expect(result?.species).toBe("Song Thrush");
+  });
+});


### PR DESCRIPTION
## Summary

- Add photo upload input to AddBirdForm and BirdEditForm (file picker, jpg/png/gif/webp, 5MB limit)
- `POST /api/uploads` saves file to filesystem (`UPLOAD_DIR` env), returns filename
- `GET /api/uploads/[filename]` serves file with canonical path check and `X-Content-Type-Options: nosniff`
- `POST /api/identify-photo` sends image as base64 to `openai/gpt-4o` via OpenRouter, parses response with existing `parseIdentification`, returns `{type, species, summary}`
- AddBirdForm: on photo upload → identify → populate type/species/notes fields and hide BirdChatWidget; if no photo, show BirdChatWidget as normal
- BirdEditForm: photo upload only (no AI identification), shows existing photo thumbnail on load
- Add `photo_path` nullable column to `bird_entries` via migration `0002_add_photo_path.sql`
- Dashboard: all 3 views (Timeline, Species, Location) show 48px inline thumbnail per bird, or "No Photo" placeholder
- 7 new unit tests for photo identification response parsing (40 total passing)

## Security fixes

- Extension allowlist (jpg/jpeg/png/gif/webp) enforced on upload — blocks SVG/HTML stored XSS
- Canonical path resolution check in serve route — blocks path traversal
- `isSafeFilename` validation on `photoPath` in `PUT /api/birds/[id]` body
- `X-Content-Type-Options: nosniff` on all served photo responses
- File input disabled during upload to prevent race condition on rapid file selection

## Test plan

- [ ] Add a new bird sighting and upload a photo — fields should auto-populate from AI, chat widget should hide
- [ ] Upload a photo that fails identification — chat widget should remain visible
- [ ] Edit an existing bird sighting and upload/replace a photo — no AI, just stores path
- [ ] Dashboard: bird sightings with photos show thumbnail; sightings without show "No Photo" in all 3 tabs
- [ ] All 40 unit tests pass: `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)