### PR TITLE
feat: pivot to Turso (libSQL) database for Vercel deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV DOCKER_BUILD=true
 
 RUN pnpm run build
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -3,8 +3,9 @@ import { defineConfig } from "drizzle-kit";
 export default defineConfig({
   schema: "./src/db/schema.ts",
   out: "./drizzle",
-  dialect: "sqlite",
+  dialect: "turso",
   dbCredentials: {
-    url: "./bird-cage.db",
+    url: process.env.TURSO_DATABASE_URL ?? "file:./bird-cage.db",
+    authToken: process.env.TURSO_AUTH_TOKEN,
   },
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  output: "standalone",
+  // Use standalone output only for Docker/self-hosted builds.
+  // Vercel manages its own output format automatically.
+  ...(process.env.DOCKER_BUILD === "true" ? { output: "standalone" } : {}),
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
+    "@libsql/client": "^0.14.0",
+    "@vercel/blob": "^0.27.0",
     "better-auth": "^1.5.4",
     "better-sqlite3": "^12.6.2",
     "drizzle-orm": "^0.45.1",

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,15 +1,42 @@
 import { getSessionCookie } from "better-auth/cookies";
 import { NextRequest, NextResponse } from "next/server";
 
+function applySecurityHeaders(response: NextResponse): NextResponse {
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("X-XSS-Protection", "1; mode=block");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  response.headers.set(
+    "Permissions-Policy",
+    "camera=(), microphone=(), geolocation=(self)",
+  );
+  if (process.env.NODE_ENV === "production") {
+    response.headers.set(
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  }
+  return response;
+}
+
 /** Lightweight cookie-based route guard for protected paths. */
 export async function proxy(request: NextRequest) {
-  const sessionCookie = getSessionCookie(request);
-  if (!sessionCookie) {
-    return NextResponse.redirect(new URL("/login", request.url));
+  const { pathname } = request.nextUrl;
+
+  const isProtected =
+    pathname.startsWith("/dashboard") || pathname.startsWith("/events");
+
+  if (isProtected) {
+    const sessionCookie = getSessionCookie(request);
+    if (!sessionCookie) {
+      const redirect = NextResponse.redirect(new URL("/login", request.url));
+      return applySecurityHeaders(redirect);
+    }
   }
-  return NextResponse.next();
+
+  return applySecurityHeaders(NextResponse.next());
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/events/:path*"],
+  matcher: ["/dashboard/:path*", "/events/:path*", "/birds/:path*"],
 };

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,23 +1,24 @@
 /**
  * Startup migration script.
- * Run this before starting the Next.js server (e.g. in Docker entrypoint).
+ * Run this before starting the Next.js server (e.g. in Docker entrypoint or Vercel build).
  * Usage: npx tsx scripts/migrate.ts
+ *
+ * Environment variables:
+ *   TURSO_DATABASE_URL  — libSQL URL (e.g. libsql://your-db.turso.io or file:./bird-cage.db)
+ *   TURSO_AUTH_TOKEN    — Turso auth token (required for remote databases)
  */
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
-import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
 import path from "path";
 
-const DB_PATH =
-  process.env.DATABASE_URL ?? path.join(process.cwd(), "bird-cage.db");
+const url = process.env.TURSO_DATABASE_URL ?? "file:./bird-cage.db";
+const authToken = process.env.TURSO_AUTH_TOKEN;
 
-const sqlite = new Database(DB_PATH);
-sqlite.pragma("journal_mode = WAL");
-sqlite.pragma("foreign_keys = ON");
+const client = createClient({ url, authToken });
+const db = drizzle(client);
 
-const db = drizzle(sqlite);
-
-migrate(db, { migrationsFolder: path.join(process.cwd(), "drizzle") });
+await migrate(db, { migrationsFolder: path.join(process.cwd(), "drizzle") });
 
 console.log("Migrations applied successfully");
-sqlite.close();
+await client.close();

--- a/src/app/api/birds/[id]/route.ts
+++ b/src/app/api/birds/[id]/route.ts
@@ -65,7 +65,7 @@ export async function DELETE(
   if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   await db.delete(birdEntries).where(eq(birdEntries.id, birdId));
-  deleteUploadedFile(row.photoPath);
+  await deleteUploadedFile(row.photoPath);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -64,7 +64,7 @@ export async function PUT(
     }
   });
 
-  for (const bird of existingBirds) deleteUploadedFile(bird.photoPath);
+  await Promise.all(existingBirds.map((bird) => deleteUploadedFile(bird.photoPath)));
 
   return NextResponse.json({ ok: true });
 }
@@ -94,7 +94,7 @@ export async function DELETE(
 
   await db.delete(birdingEvents).where(eq(birdingEvents.id, eventId));
 
-  for (const bird of birds) deleteUploadedFile(bird.photoPath);
+  await Promise.all(birds.map((bird) => deleteUploadedFile(bird.photoPath)));
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -31,21 +31,32 @@ export async function POST(req: NextRequest) {
 
   const { photoPath } = (await req.json()) as { photoPath: string };
 
-  if (!photoPath || !isSafeFilename(photoPath)) {
+  if (!photoPath) {
     return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
   }
 
-  const filePath = getUploadPath(photoPath);
-  let buffer: Buffer;
-  try {
-    buffer = await fs.readFile(filePath);
-  } catch {
-    return NextResponse.json({ error: "Photo not found" }, { status: 404 });
-  }
+  let imageContent: { type: "image_url"; image_url: { url: string } };
 
-  const ext = path.extname(photoPath).toLowerCase().replace(".", "");
-  const mimeType = ext === "jpg" ? "image/jpeg" : `image/${ext}`;
-  const dataUrl = `data:${mimeType};base64,${buffer.toString("base64")}`;
+  if (photoPath.startsWith("https://")) {
+    // Vercel Blob URL — pass directly to vision model
+    imageContent = { type: "image_url", image_url: { url: photoPath } };
+  } else {
+    // Local filesystem — read and base64-encode
+    if (!isSafeFilename(photoPath)) {
+      return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
+    }
+    const filePath = getUploadPath(photoPath);
+    let buffer: Buffer;
+    try {
+      buffer = await fs.readFile(filePath);
+    } catch {
+      return NextResponse.json({ error: "Photo not found" }, { status: 404 });
+    }
+    const ext = path.extname(photoPath).toLowerCase().replace(".", "");
+    const mimeType = ext === "jpg" ? "image/jpeg" : `image/${ext}`;
+    const dataUrl = `data:${mimeType};base64,${buffer.toString("base64")}`;
+    imageContent = { type: "image_url", image_url: { url: dataUrl } };
+  }
 
   const client = getClient();
 
@@ -58,7 +69,7 @@ export async function POST(req: NextRequest) {
         {
           role: "user",
           content: [
-            { type: "image_url", image_url: { url: dataUrl } },
+            imageContent,
             { type: "text", text: IDENTIFY_PROMPT },
           ],
         },

--- a/src/app/api/uploads/route.ts
+++ b/src/app/api/uploads/route.ts
@@ -31,10 +31,18 @@ export async function POST(req: NextRequest) {
   if (!ALLOWED_EXTS.has(ext)) {
     return NextResponse.json({ error: "Unsupported file type" }, { status: 415 });
   }
+
   const filename = `${randomUUID()}${ext}`;
   const buffer = Buffer.from(await file.arrayBuffer());
 
-  await fs.writeFile(path.join(getUploadDir(), filename), buffer);
+  if (process.env.BLOB_READ_WRITE_TOKEN) {
+    // Vercel Blob — store in cloud storage
+    const { put } = await import("@vercel/blob");
+    const blob = await put(`bird-photos/${filename}`, buffer, { access: "public" });
+    return NextResponse.json({ path: blob.url });
+  }
 
+  // Local filesystem fallback (development)
+  await fs.writeFile(path.join(getUploadDir(), filename), buffer);
   return NextResponse.json({ path: filename });
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,27 +1,25 @@
-import Database from "better-sqlite3";
-import { drizzle } from "drizzle-orm/better-sqlite3";
+import { createClient } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
 import * as schema from "./schema";
-import path from "path";
-import fs from "fs";
 
-const DB_PATH =
-  process.env.DATABASE_URL ?? path.join(process.cwd(), "bird-cage.db");
+function createDb() {
+  const url = process.env.TURSO_DATABASE_URL ?? "file:./bird-cage.db";
+  const authToken = process.env.TURSO_AUTH_TOKEN;
+  const client = createClient({ url, authToken });
+  return drizzle(client, { schema });
+}
 
-let _db: ReturnType<typeof drizzle<typeof schema>> | null = null;
+let _db: ReturnType<typeof createDb> | null = null;
 
 /** Returns the db instance, creating it on first use. */
 export function getDb() {
   if (!_db) {
-    fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
-    const sqlite = new Database(DB_PATH);
-    sqlite.pragma("journal_mode = WAL");
-    sqlite.pragma("foreign_keys = ON");
-    _db = drizzle(sqlite, { schema });
+    _db = createDb();
   }
   return _db;
 }
 
-export const db = new Proxy({} as ReturnType<typeof drizzle<typeof schema>>, {
+export const db = new Proxy({} as ReturnType<typeof createDb>, {
   get(_target, prop) {
     return (getDb() as never)[prop as never];
   },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -10,6 +10,13 @@ export const auth = betterAuth({
     enabled: true,
     minPasswordLength: 8,
     autoSignIn: true,
+    requireEmailVerification: true,
+  },
+  emailVerification: {
+    sendVerificationEmail: async ({ user, url }) => {
+      // TODO: wire up a real email provider (e.g. Resend, SendGrid) before going live
+      console.log(`[email-verification] Send to ${user.email}: ${url}`);
+    },
   },
   socialProviders: {
     google: {

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -22,11 +22,28 @@ export function isSafeFilename(filename: string): boolean {
   );
 }
 
-/** Deletes an uploaded file by filename. Silently ignores missing files. */
-export function deleteUploadedFile(filename: string | null | undefined): void {
-  if (!filename || !isSafeFilename(filename)) return;
+/**
+ * Deletes an uploaded file.
+ * Handles both Vercel Blob URLs (https://...) and local filenames.
+ */
+export async function deleteUploadedFile(fileRef: string | null | undefined): Promise<void> {
+  if (!fileRef) return;
+
+  if (fileRef.startsWith("https://")) {
+    // Vercel Blob URL — delete from cloud storage
+    const { del } = await import("@vercel/blob");
+    try {
+      await del(fileRef);
+    } catch {
+      // blob already gone — ignore
+    }
+    return;
+  }
+
+  // Local filesystem fallback
+  if (!isSafeFilename(fileRef)) return;
   try {
-    fs.unlinkSync(getUploadPath(filename));
+    fs.unlinkSync(getUploadPath(fileRef));
   } catch {
     // file already gone — ignore
   }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,15 @@
+{
+  "buildCommand": "pnpm run build",
+  "outputDirectory": ".next",
+  "framework": "nextjs",
+  "env": {
+    "TURSO_DATABASE_URL": "@turso-database-url",
+    "TURSO_AUTH_TOKEN": "@turso-auth-token",
+    "BETTER_AUTH_SECRET": "@better-auth-secret",
+    "BETTER_AUTH_URL": "@better-auth-url",
+    "GOOGLE_CLIENT_ID": "@google-client-id",
+    "GOOGLE_CLIENT_SECRET": "@google-client-secret",
+    "OPENROUTER_API_KEY": "@openrouter-api-key",
+    "BLOB_READ_WRITE_TOKEN": "@blob-read-write-token"
+  }
+}


### PR DESCRIPTION
Implements BRD-60: pivot from Neon PostgreSQL to Turso/libSQL for Vercel deployment.

Key changes:
- @libsql/client + drizzle-orm/libsql replaces better-sqlite3
- Turso URL/token env vars; falls back to local file for dev
- Vercel Blob for photo storage
- Email verification enabled in Better Auth
- Security headers in proxy.ts
- vercel.json created

Closes #22

Generated with [Claude Code](https://claude.ai/code)