### PR TITLE
feat(auth): dynamically resolve base URL per environment (BRD-73)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
 # Required - generate with: npx @better-auth/cli secret
 BETTER_AUTH_SECRET=
 
-# App URL (used by Better Auth for callbacks)
-BETTER_AUTH_URL=http://localhost:3000
+# App URL — set to your production domain on Vercel (e.g. https://your-app.vercel.app)
+# Used as Better Auth baseURL in production. In preview/local envs this is derived automatically.
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Vercel sets these automatically in deployed environments — do NOT set them in .env.local
+# VERCEL_ENV=production|preview|development
+# VERCEL_URL=auto-generated-preview-url.vercel.app
 
 # Google OAuth - register at https://console.cloud.google.com
 # Callback URL to register: http://localhost:3000/api/auth/callback/google

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,10 +3,22 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import { Resend } from "resend";
 import { db } from "../db";
+import { getAuthBaseUrl } from "./get-auth-base-url";
+
+const baseURL = getAuthBaseUrl();
 
 export const auth = betterAuth({
-  baseURL: process.env.BETTER_AUTH_URL,
+  baseURL,
   secret: process.env.BETTER_AUTH_SECRET,
+  trustedOrigins: [
+    "http://localhost:3000",
+    ...(process.env.NEXT_PUBLIC_APP_URL
+      ? [process.env.NEXT_PUBLIC_APP_URL]
+      : []),
+    ...(process.env.VERCEL_URL
+      ? [`https://${process.env.VERCEL_URL}`]
+      : []),
+  ],
   database: drizzleAdapter(db, { provider: "sqlite" }),
   emailAndPassword: {
     enabled: true,

--- a/src/lib/get-auth-base-url.ts
+++ b/src/lib/get-auth-base-url.ts
@@ -1,0 +1,26 @@
+/**
+ * Determines the correct base URL for Better Auth based on the current environment.
+ *
+ * - Production (VERCEL_ENV === "production"): uses NEXT_PUBLIC_APP_URL
+ * - Preview (VERCEL_ENV === "preview"): uses https://VERCEL_URL
+ * - Local development: falls back to http://localhost:3000
+ */
+export function getAuthBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production") {
+    return process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  }
+
+  if (process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+
+  return "http://localhost:3000";
+}
+
+/**
+ * Builds a full auth URL by appending a path to the base URL.
+ */
+export function getAuthUrl(path: string): string {
+  const base = getAuthBaseUrl();
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}


### PR DESCRIPTION
- Add `src/lib/get-auth-base-url.ts` with `getAuthBaseUrl()` and `getAuthUrl()` helpers
  - production: uses NEXT_PUBLIC_APP_URL
  - preview: uses https://VERCEL_URL
  - local: falls back to http://localhost:3000
- Update `src/lib/auth.ts` to use dynamic baseURL and trustedOrigins covering all three environments; removes hardcoded BETTER_AUTH_URL
- Update `.env.example` to document NEXT_PUBLIC_APP_URL requirement and note that VERCEL_ENV/VERCEL_URL are set automatically by Vercel