### PR TITLE
fix: use environment-aware URL in identify-photo and chat routes

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import { NextRequest } from "next/server";
 import { auth } from "../../../lib/auth";
+import { getAuthBaseUrl } from "../../../lib/get-auth-base-url";
 
 const SYSTEM_PROMPT = `You are an expert ornithologist helping birding enthusiasts identify birds.
 
@@ -22,8 +23,7 @@ function getClient() {
     apiKey: process.env.OPENROUTER_API_KEY,
     baseURL: "https://openrouter.ai/api/v1",
     defaultHeaders: {
-      "HTTP-Referer":
-        process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+      "HTTP-Referer": getAuthBaseUrl(),
       "X-Title": "Bird Cage",
     },
   });

--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { auth } from "@/lib/auth";
 import { getUploadPath, isSafeFilename } from "@/lib/uploads";
 import { parseIdentification } from "@/lib/chat";
+import { getAuthBaseUrl } from "@/lib/get-auth-base-url";
 
 const VISION_MODEL = "openai/gpt-4o";
 
@@ -19,7 +20,7 @@ function getClient() {
     apiKey: process.env.OPENROUTER_API_KEY,
     baseURL: "https://openrouter.ai/api/v1",
     defaultHeaders: {
-      "HTTP-Referer": process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+      "HTTP-Referer": getAuthBaseUrl(),
       "X-Title": "Bird Cage",
     },
   });

--- a/src/lib/get-auth-base-url.ts
+++ b/src/lib/get-auth-base-url.ts
@@ -1,0 +1,23 @@
+/**
+ * Returns the correct base URL for the current environment:
+ * - Vercel production: uses NEXT_PUBLIC_APP_URL
+ * - Vercel preview: uses https://<VERCEL_URL> (auto-generated per deployment)
+ * - Local development: falls back to http://localhost:3000
+ */
+export function getAuthBaseUrl(): string {
+  if (process.env.VERCEL_ENV === "production") {
+    return process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+  }
+  if (process.env.VERCEL_ENV === "preview" && process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return "http://localhost:3000";
+}
+
+/**
+ * Builds a full URL by appending a path to the environment-aware base URL.
+ */
+export function getAuthUrl(path: string): string {
+  const base = getAuthBaseUrl();
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}


### PR DESCRIPTION
Replace NEXT_PUBLIC_APP_URL with getAuthBaseUrl() for the OpenRouter HTTP-Referer header so preview deployments use their VERCEL_URL instead of falling back to localhost:3000.