### PR TITLE
Fix photo identification in Vercel environments via client-side base64

### DIFF
--- a/drizzle/0003_add_photo_data.sql
+++ b/drizzle/0003_add_photo_data.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `bird_entries` ADD COLUMN `photo_data` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1742000000000,
       "tag": "0002_add_photo_path",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1742100000000,
+      "tag": "0003_add_photo_data",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -21,6 +21,20 @@ const db = drizzle(client);
 async function main() {
   await migrate(db, { migrationsFolder: path.join(process.cwd(), "drizzle") });
   console.log("Migrations applied successfully");
+
+  // Idempotent schema safety check: ensure photo_data column exists.
+  // Drizzle's migration tracker may skip a migration if its hash was already
+  // recorded (e.g. from a prior failed run), leaving the column missing.
+  const tableInfo = await client.execute("PRAGMA table_info(bird_entries)");
+  const hasPhotoData = tableInfo.rows.some((row) => row[1] === "photo_data");
+  if (!hasPhotoData) {
+    console.log("photo_data column missing — applying schema fix");
+    await client.execute(
+      "ALTER TABLE bird_entries ADD COLUMN photo_data text"
+    );
+    console.log("photo_data column added successfully");
+  }
+
   await client.close();
 }
 

--- a/src/app/api/birds/[id]/route.ts
+++ b/src/app/api/birds/[id]/route.ts
@@ -26,19 +26,19 @@ export async function PUT(
   if (!row) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   const body = await req.json();
-  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath } = body;
+  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath, photoData } = body;
 
   if (!type || !species || !locationName || !dateStamp) {
     return NextResponse.json({ error: "Missing required fields" }, { status: 400 });
   }
 
-  if (photoPath && !isSafeFilename(photoPath)) {
+  if (photoPath && !isSafeFilename(photoPath) && !photoPath.startsWith("https://")) {
     return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
   }
 
   await db
     .update(birdEntries)
-    .set({ type, species, locationName, lat: lat ?? null, lng: lng ?? null, dateStamp, notes: notes ?? null, photoPath: photoPath ?? null })
+    .set({ type, species, locationName, lat: lat ?? null, lng: lng ?? null, dateStamp, notes: notes ?? null, photoPath: photoData ? null : (photoPath ?? null), photoData: photoData ?? null })
     .where(eq(birdEntries.id, birdId));
 
   return NextResponse.json({ ok: true });

--- a/src/app/api/events/[id]/birds/route.ts
+++ b/src/app/api/events/[id]/birds/route.ts
@@ -22,7 +22,7 @@ export async function POST(
 
   if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath } = await req.json();
+  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath, photoData } = await req.json();
 
   const [bird] = await db
     .insert(birdEntries)
@@ -35,7 +35,8 @@ export async function POST(
       lng: lng ?? null,
       dateStamp,
       notes: notes ?? null,
-      photoPath: photoPath ?? null,
+      photoPath: photoData ? null : (photoPath ?? null),
+      photoData: photoData ?? null,
     })
     .returning();
 

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -13,6 +13,8 @@ type BirdPayload = {
   lng?: number | null;
   dateStamp: string;
   notes?: string | null;
+  photoPath?: string | null;
+  photoData?: string | null;
 };
 
 export async function PUT(
@@ -59,6 +61,8 @@ export async function PUT(
           lng: b.lng ?? null,
           dateStamp: b.dateStamp,
           notes: b.notes ?? null,
+          photoPath: b.photoData ? null : (b.photoPath ?? null),
+          photoData: b.photoData ?? null,
         })),
       );
     }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
           dateStamp: string;
           notes?: string;
           photoPath?: string;
+          photoData?: string;
         }) => ({
           eventId: event.id,
           type: b.type,
@@ -37,7 +38,8 @@ export async function POST(req: NextRequest) {
           lng: b.lng ?? null,
           dateStamp: b.dateStamp,
           notes: b.notes ?? null,
-          photoPath: b.photoPath ?? null,
+          photoPath: b.photoData ? null : (b.photoPath ?? null),
+          photoData: b.photoData ?? null,
         }),
       ),
     );

--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -1,9 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import OpenAI from "openai";
-import fs from "fs/promises";
-import path from "path";
 import { auth } from "@/lib/auth";
-import { getUploadPath, isSafeFilename } from "@/lib/uploads";
 import { parseIdentification } from "@/lib/chat";
 import { getAuthBaseUrl } from "@/lib/get-auth-base-url";
 
@@ -30,33 +27,11 @@ export async function POST(req: NextRequest) {
   const session = await auth.api.getSession({ headers: req.headers });
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { photoPath } = (await req.json()) as { photoPath: string };
+  const body = (await req.json()) as { photoBase64?: string };
+  const { photoBase64 } = body;
 
-  if (!photoPath) {
-    return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
-  }
-
-  let imageContent: { type: "image_url"; image_url: { url: string } };
-
-  if (photoPath.startsWith("https://")) {
-    // Vercel Blob URL — pass directly to vision model
-    imageContent = { type: "image_url", image_url: { url: photoPath } };
-  } else {
-    // Local filesystem — read and base64-encode
-    if (!isSafeFilename(photoPath)) {
-      return NextResponse.json({ error: "Invalid photo path" }, { status: 400 });
-    }
-    const filePath = getUploadPath(photoPath);
-    let buffer: Buffer;
-    try {
-      buffer = await fs.readFile(filePath);
-    } catch {
-      return NextResponse.json({ error: "Photo not found" }, { status: 404 });
-    }
-    const ext = path.extname(photoPath).toLowerCase().replace(".", "");
-    const mimeType = ext === "jpg" ? "image/jpeg" : `image/${ext}`;
-    const dataUrl = `data:${mimeType};base64,${buffer.toString("base64")}`;
-    imageContent = { type: "image_url", image_url: { url: dataUrl } };
+  if (!photoBase64 || !photoBase64.startsWith("data:image/")) {
+    return NextResponse.json({ error: "Invalid or missing photo data" }, { status: 400 });
   }
 
   const client = getClient();
@@ -70,7 +45,7 @@ export async function POST(req: NextRequest) {
         {
           role: "user",
           content: [
-            imageContent,
+            { type: "image_url", image_url: { url: photoBase64 } },
             { type: "text", text: IDENTIFY_PROMPT },
           ],
         },

--- a/src/components/AddBirdForm.tsx
+++ b/src/components/AddBirdForm.tsx
@@ -25,7 +25,7 @@ export default function AddBirdForm({ eventId }: Props) {
   const [saving, setSaving] = useState(false);
   const [geoLoading, setGeoLoading] = useState(false);
   const [geoError, setGeoError] = useState("");
-  const [photoPath, setPhotoPath] = useState("");
+  const [photoData, setPhotoData] = useState("");
   const [photoPreview, setPhotoPreview] = useState("");
   const [photoStatus, setPhotoStatus] = useState("");
   const [photoError, setPhotoError] = useState("");
@@ -53,39 +53,29 @@ export default function AddBirdForm({ eventId }: Props) {
   }
 
   async function handlePhotoFile(file: File) {
-
     setPhotoError("");
-    setPhotoStatus("Uploading photo...");
+    setPhotoStatus("Reading photo...");
     setPhotoUploading(true);
-    setPhotoPreview((prev) => {
-      if (prev.startsWith("blob:")) URL.revokeObjectURL(prev);
-      return URL.createObjectURL(file);
-    });
-
-    const form = new FormData();
-    form.append("file", file);
+    setPhotoPreview(URL.createObjectURL(file));
 
     try {
-      const uploadRes = await fetch("/api/uploads", { method: "POST", body: form });
-      if (!uploadRes.ok) {
-        const body = await uploadRes.json().catch(() => ({}));
-        setPhotoError((body as { error?: string }).error ?? "Upload failed");
-        setPhotoStatus("");
-        return;
-      }
-
-      const { path: uploadedPath } = (await uploadRes.json()) as { path: string };
-      setPhotoPath(uploadedPath);
+      const base64 = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+      setPhotoData(base64);
       setPhotoStatus("Identifying bird from photo...");
 
       const identRes = await fetch("/api/identify-photo", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ photoPath: uploadedPath }),
+        body: JSON.stringify({ photoBase64: base64 }),
       });
 
       if (!identRes.ok) {
-        setPhotoStatus("Photo uploaded. Could not identify bird — please use the chat below.");
+        setPhotoStatus("Photo ready. Could not identify bird — please use the chat below.");
         return;
       }
 
@@ -125,7 +115,7 @@ export default function AddBirdForm({ eventId }: Props) {
           lng: lng !== "" ? parseFloat(lng) : null,
           dateStamp,
           notes,
-          photoPath: photoPath || null,
+          photoData: photoData || null,
         }),
       });
 

--- a/src/components/BirdEditForm.tsx
+++ b/src/components/BirdEditForm.tsx
@@ -25,8 +25,13 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
   const [geoLoading, setGeoLoading] = useState(false);
   const [geoError, setGeoError] = useState("");
   const [photoPath, setPhotoPath] = useState(bird.photoPath ?? "");
+  const [photoData, setPhotoData] = useState(bird.photoData ?? "");
   const [photoPreview, setPhotoPreview] = useState(
-    bird.photoPath ? `/api/uploads/${bird.photoPath}` : "",
+    bird.photoData
+      ? bird.photoData
+      : bird.photoPath
+      ? `/api/uploads/${bird.photoPath}`
+      : "",
   );
   const [photoStatus, setPhotoStatus] = useState("");
   const [photoError, setPhotoError] = useState("");
@@ -53,30 +58,21 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
   }
 
   async function handlePhotoFile(file: File) {
-
     setPhotoError("");
-    setPhotoStatus("Uploading photo...");
+    setPhotoStatus("Reading photo...");
     setPhotoUploading(true);
-    setPhotoPreview((prev) => {
-      if (prev.startsWith("blob:")) URL.revokeObjectURL(prev);
-      return URL.createObjectURL(file);
-    });
-
-    const form = new FormData();
-    form.append("file", file);
+    setPhotoPreview(URL.createObjectURL(file));
 
     try {
-      const res = await fetch("/api/uploads", { method: "POST", body: form });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        setPhotoError((body as { error?: string }).error ?? "Upload failed");
-        setPhotoStatus("");
-        return;
-      }
-
-      const { path: uploadedPath } = (await res.json()) as { path: string };
-      setPhotoPath(uploadedPath);
-      setPhotoStatus("Photo uploaded.");
+      const base64 = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+      setPhotoData(base64);
+      setPhotoPath("");
+      setPhotoStatus("Photo ready.");
     } catch {
       setPhotoError("Something went wrong. Please try again.");
       setPhotoStatus("");
@@ -107,7 +103,8 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
           lng: lng !== "" ? parseFloat(lng) : null,
           dateStamp,
           notes,
-          photoPath: photoPath || null,
+          photoPath: photoData ? null : (photoPath || null),
+          photoData: photoData || null,
         }),
       });
 

--- a/src/components/DashboardTabs.tsx
+++ b/src/components/DashboardTabs.tsx
@@ -71,8 +71,8 @@ function TimelineView({ events }: { events: EventWithBirds[] }) {
             <ul className={styles.birdList}>
               {event.birds.map((bird) => (
                 <li key={bird.id} className={styles.birdItem}>
-                  {bird.photoPath
-                    ? <img src={`/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
+                  {bird.photoData || bird.photoPath
+                    ? <img src={bird.photoData ?? `/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
                     : <div className={styles.noPhoto}>No Photo</div>}
                   <div className={styles.birdItemInfo}>
                     <span className={styles.birdName}>{bird.species}</span>
@@ -113,8 +113,8 @@ function SpeciesView({ events }: { events: EventWithBirds[] }) {
           <ul className={styles.birdList}>
             {entries.map(({ bird, eventTitle, eventDate }) => (
               <li key={bird.id} className={styles.birdItem}>
-                {bird.photoPath
-                  ? <img src={`/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
+                {bird.photoData || bird.photoPath
+                  ? <img src={bird.photoData ?? `/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
                   : <div className={styles.noPhoto}>No Photo</div>}
                 <div className={styles.birdItemInfo}>
                   <span className={styles.birdName}>{eventTitle}</span>
@@ -157,8 +157,8 @@ function LocationView({ events }: { events: EventWithBirds[] }) {
             <ul className={styles.birdList}>
               {entries.map(({ bird, eventTitle, eventDate }) => (
                 <li key={bird.id} className={styles.birdItem}>
-                  {bird.photoPath
-                    ? <img src={`/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
+                  {bird.photoData || bird.photoPath
+                    ? <img src={bird.photoData ?? `/api/uploads/${bird.photoPath}`} alt={bird.species} className={styles.birdThumb} />
                     : <div className={styles.noPhoto}>No Photo</div>}
                   <div className={styles.birdItemInfo}>
                     <span className={styles.birdName}>{bird.species} ({bird.type})</span>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -17,6 +17,7 @@ interface BirdFormEntry {
   dateStamp: string;
   notes: string;
   photoPath: string;
+  photoData: string;
 }
 
 interface BirdPhotoState {
@@ -59,6 +60,7 @@ function emptyBird(): BirdFormEntry {
     dateStamp: new Date().toISOString().slice(0, 10),
     notes: "",
     photoPath: "",
+    photoData: "",
   };
 }
 
@@ -72,6 +74,7 @@ function toBirdFormEntry(b: BirdEntry): BirdFormEntry {
     dateStamp: b.dateStamp,
     notes: b.notes ?? "",
     photoPath: b.photoPath ?? "",
+    photoData: b.photoData ?? "",
   };
 }
 
@@ -131,35 +134,29 @@ export default function EventForm({ initialData }: Props) {
   }
 
   async function handlePhotoFile(index: number, file: File) {
-
-    updatePhoto(index, { error: "", status: "Uploading photo...", uploading: true });
-    const preview = URL.createObjectURL(file);
-    updatePhoto(index, { preview });
-
-    const form = new FormData();
-    form.append("file", file);
+    updatePhoto(index, { error: "", status: "Reading photo...", uploading: true });
+    updatePhoto(index, { preview: URL.createObjectURL(file) });
 
     try {
-      const uploadRes = await fetch("/api/uploads", { method: "POST", body: form });
-      if (!uploadRes.ok) {
-        const body = await uploadRes.json().catch(() => ({}));
-        updatePhoto(index, { error: (body as { error?: string }).error ?? "Upload failed", status: "", uploading: false });
-        return;
-      }
-
-      const { path: uploadedPath } = (await uploadRes.json()) as { path: string };
-      updateBird(index, "photoPath", uploadedPath);
+      const base64 = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      });
+      updateBird(index, "photoData", base64);
+      updateBird(index, "photoPath", "");
 
       updatePhoto(index, { status: "Identifying bird from photo..." });
 
       const identRes = await fetch("/api/identify-photo", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ photoPath: uploadedPath }),
+        body: JSON.stringify({ photoBase64: base64 }),
       });
 
       if (!identRes.ok) {
-        updatePhoto(index, { status: "Photo uploaded. Could not identify bird — please use the chat below.", uploading: false });
+        updatePhoto(index, { status: "Photo ready. Could not identify bird — please use the chat below.", uploading: false });
         return;
       }
 
@@ -211,7 +208,8 @@ export default function EventForm({ initialData }: Props) {
           ...b,
           lat: b.lat !== "" ? parseFloat(b.lat) : null,
           lng: b.lng !== "" ? parseFloat(b.lng) : null,
-          photoPath: b.photoPath || null,
+          photoPath: b.photoData ? null : (b.photoPath || null),
+          photoData: b.photoData || null,
         })),
     };
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -117,6 +117,7 @@ export const birdEntries = sqliteTable("bird_entries", {
   dateStamp: text("date_stamp").notNull(),
   notes: text("notes"),
   photoPath: text("photo_path"),
+  photoData: text("photo_data"),
 });
 
 // Relations

--- a/src/tests/unit/csv.test.ts
+++ b/src/tests/unit/csv.test.ts
@@ -22,6 +22,7 @@ const baseBird: BirdEntry = {
   dateStamp: "2024-03-01",
   notes: "Spotted near the pond",
   photoPath: null,
+  photoData: null,
 };
 
 describe("generateCsv", () => {


### PR DESCRIPTION
- Add photo_data column to bird_entries table for base64 image storage
- Add drizzle migration 0003_add_photo_data.sql
- Rewrite /api/identify-photo to accept photoBase64 in request body, eliminating all server-side file reads that fail on Vercel's ephemeral FS
- Update AddBirdForm, BirdEditForm, EventForm to convert files to base64 data URLs client-side using FileReader, removing dependency on upload API for identification flow
- Update all bird/event API routes to persist photoData (base64) column instead of photoPath for new uploads
- Update DashboardTabs to render thumbnails from photoData data URLs with backward compatibility fallback to /api/uploads/[photoPath] for existing records
- Update csv.test.ts baseBird fixture to include new photoData field