### PR TITLE
fix(BRD-81): redirect signup to verify-email and add email verificati…

### DIFF
--- a/src/app/api/birds/[id]/route.ts
+++ b/src/app/api/birds/[id]/route.ts
@@ -11,6 +11,7 @@ export async function PUT(
 ) {
   const session = await auth.api.getSession({ headers: req.headers });
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session.user.emailVerified) return NextResponse.json({ error: "Email not verified" }, { status: 403 });
 
   const { id } = await params;
   const birdId = parseInt(id, 10);

--- a/src/app/api/events/[id]/birds/route.ts
+++ b/src/app/api/events/[id]/birds/route.ts
@@ -10,6 +10,7 @@ export async function POST(
 ) {
   const session = await auth.api.getSession({ headers: req.headers });
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session.user.emailVerified) return NextResponse.json({ error: "Email not verified" }, { status: 403 });
 
   const { id } = await params;
   const eventId = parseInt(id, 10);

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -23,6 +23,7 @@ export async function PUT(
 ) {
   const session = await auth.api.getSession({ headers: req.headers });
   if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session.user.emailVerified) return NextResponse.json({ error: "Email not verified" }, { status: 403 });
 
   const { id } = await params;
   const eventId = parseInt(id, 10);

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -7,6 +7,8 @@ export async function POST(req: NextRequest) {
   const session = await auth.api.getSession({ headers: req.headers });
   if (!session)
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (!session.user.emailVerified)
+    return NextResponse.json({ error: "Email not verified" }, { status: 403 });
 
   const body = await req.json();
   const { title, date, notes, birds } = body;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -7,7 +7,10 @@ import Image from "next/image";
 
 export default async function SignupPage() {
   const session = await getSession();
-  if (session) redirect("/dashboard");
+  if (session) {
+    if (session.user.emailVerified) redirect("/dashboard");
+    else redirect("/verify-email");
+  }
 
   return (
     <main className={styles.main}>

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -1,14 +1,14 @@
-import { requireAuth } from "../../lib/session";
+import { getSession } from "../../lib/session";
 import { redirect } from "next/navigation";
 import VerifyEmailClient from "./VerifyEmailClient";
 import styles from "../login/page.module.css";
 import Image from "next/image";
 
 export default async function VerifyEmailPage() {
-  const session = await requireAuth();
+  const session = await getSession();
 
   // Already verified — send to dashboard
-  if (session.user.emailVerified) redirect("/dashboard");
+  if (session?.user.emailVerified) redirect("/dashboard");
 
   return (
     <main className={styles.main}>
@@ -16,8 +16,10 @@ export default async function VerifyEmailPage() {
         <Image src="/logo.svg" alt="Bird Cage" width={220} height={147} className={styles.logoImg} />
         <h1 className={styles.title}>Check your email</h1>
         <p className={styles.subtitle}>
-          We sent a verification link to <strong>{session.user.email}</strong>. Click
-          the link in the email to activate your account.
+          {session?.user.email
+            ? <>We sent a verification link to <strong>{session.user.email}</strong>. Click the link in the email to activate your account.</>
+            : "We sent a verification link to your email. Click the link to activate your account."
+          }
         </p>
         <VerifyEmailClient />
         <p className={styles.hint}>

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -25,7 +25,7 @@ export default function SignupForm() {
         if (error) {
           setError(error);
         } else {
-          router.push("/dashboard");
+          router.push("/verify-email");
         }
       } catch (err) {
         console.error("Signup error:", err);


### PR DESCRIPTION
…on guards

- SignupForm.tsx: redirect to /verify-email instead of /dashboard after successful signup
- signup/page.tsx: redirect authenticated unverified users to /verify-email instead of /dashboard
- API routes (events, birds): add 403 response for unverified email on write operations