### PR TITLE
fix: redirect unverified users to /verify-email on sign in

### DIFF
--- a/src/app/login/actions.ts
+++ b/src/app/login/actions.ts
@@ -1,12 +1,18 @@
 "use server";
 import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
 
 export async function signInAction(email: string, password: string) {
   try {
     await auth.api.signInEmail({ body: { email, password } });
-    return { error: null };
+    // Check email verification status after successful sign-in
+    const session = await auth.api.getSession({ headers: await headers() });
+    if (session && !session.user.emailVerified) {
+      return { error: null, redirectTo: "/verify-email" };
+    }
+    return { error: null, redirectTo: null };
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Invalid email or password";
-    return { error: msg };
+    return { error: msg, redirectTo: null };
   }
 }

--- a/src/app/verify-email/VerifyEmailClient.tsx
+++ b/src/app/verify-email/VerifyEmailClient.tsx
@@ -1,12 +1,21 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { authClient } from "../../lib/auth-client";
 import styles from "./VerifyEmailClient.module.css";
 import authStyles from "../login/page.module.css";
 
 export default function VerifyEmailClient() {
+  const router = useRouter();
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
   const [message, setMessage] = useState("");
+
+  async function handleSignOut() {
+    await authClient.signOut({
+      fetchOptions: { onSuccess: () => router.push("/login") },
+    });
+  }
 
   async function handleResend() {
     setStatus("loading");
@@ -39,6 +48,12 @@ export default function VerifyEmailClient() {
       >
         {status === "loading" ? "Sending…" : "Resend verification email"}
       </button>
+      <p className={authStyles.hint}>
+        Wrong account?{" "}
+        <button onClick={handleSignOut} className={authStyles.link}>
+          Sign out
+        </button>
+      </p>
     </div>
   );
 }

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -22,12 +22,6 @@ export default async function VerifyEmailPage() {
           }
         </p>
         <VerifyEmailClient />
-        <p className={styles.hint}>
-          Wrong account?{" "}
-          <a href="/api/auth/sign-out?callbackURL=/login" className={styles.link}>
-            Sign out
-          </a>
-        </p>
       </div>
     </main>
   );

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -20,13 +20,11 @@ export default function LoginForm() {
 
     startTransition(async () => {
       try {
-        const { error } = await signInAction(email, password);
+        const { error, redirectTo } = await signInAction(email, password);
         if (error) {
-          if (error.includes("EMAIL_NOT_VERIFIED") || error.includes("email not verified")) {
-            router.push("/verify-email");
-          } else {
-            setError(error);
-          }
+          setError(error);
+        } else if (redirectTo) {
+          router.push(redirectTo);
         } else {
           router.push("/dashboard");
         }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -24,7 +24,7 @@ export const auth = betterAuth({
     enabled: true,
     minPasswordLength: 8,
     autoSignIn: true,
-    requireEmailVerification: true,
+    requireEmailVerification: false,
   },
   emailVerification: {
     sendVerificationEmail: async ({ user, url }) => {


### PR DESCRIPTION
Fixes #41

Allow sign-in for unverified users so a session is created, then redirect to `/verify-email`. This ensures the "Resend verification email" button works because the user is authenticated.

Generated with [Claude Code](https://claude.ai/code)