### PR TITLE
feat: add admin user management to profile page (BRD-95)

### DIFF
--- a/src/app/dashboard/admin/users/[id]/edit/page.module.css
+++ b/src/app/dashboard/admin/users/[id]/edit/page.module.css
@@ -1,0 +1,35 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-bg-light);
+}
+
+.header {
+  background: var(--color-bg-white);
+  border-bottom: 1px solid var(--color-border-medium);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: var(--color-primary-blue);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+}
+
+.main {
+  max-width: 560px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}

--- a/src/app/dashboard/admin/users/[id]/edit/page.tsx
+++ b/src/app/dashboard/admin/users/[id]/edit/page.tsx
@@ -1,0 +1,40 @@
+import { requireAdminAuth } from "@/lib/session";
+import { getUserById } from "@/lib/dal/users";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import AdminUserEditForm from "@/components/AdminUserEditForm";
+import styles from "./page.module.css";
+
+export default async function AdminUserEditPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string }>;
+}) {
+  const { dbUser } = await requireAdminAuth();
+  const { id } = await params;
+  const { from } = await searchParams;
+  const returnTo = from ?? "/dashboard/admin/users";
+
+  const targetUser = await getUserById(id);
+  if (!targetUser) notFound();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href={returnTo} className={styles.back}>
+          ← Back
+        </Link>
+        <h1 className={styles.title}>Edit User</h1>
+      </header>
+      <main className={styles.main}>
+        <AdminUserEditForm
+          targetUser={targetUser}
+          currentUserId={dbUser.id}
+          returnTo={returnTo}
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/users/actions.ts
+++ b/src/app/dashboard/admin/users/actions.ts
@@ -1,0 +1,123 @@
+"use server";
+
+import { headers } from "next/headers";
+import { Resend } from "resend";
+import { eq } from "drizzle-orm";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { user as userTable } from "@/db/schema";
+import { updateUserAdmin, deleteUserAndData } from "@/lib/dal/users";
+
+export type AdminResult = { success: true } | { error: string };
+
+async function requireAdmin(): Promise<{ id: string } | null> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return null;
+  if (!session.user.emailVerified) return null;
+
+  const [dbUser] = await db
+    .select({ role: userTable.role, id: userTable.id })
+    .from(userTable)
+    .where(eq(userTable.id, session.user.id))
+    .limit(1);
+
+  if (!dbUser || dbUser.role !== "admin") return null;
+  return { id: session.user.id };
+}
+
+export async function updateUserAsAdminAction(
+  targetUserId: string,
+  name: string,
+  email: string,
+  role: "user" | "admin",
+): Promise<AdminResult> {
+  const admin = await requireAdmin();
+  if (!admin) return { error: "Unauthorized." };
+
+  if (!name.trim()) return { error: "Name is required." };
+  if (!email.trim()) return { error: "Email is required." };
+  if (role !== "user" && role !== "admin") return { error: "Invalid role." };
+
+  // Cannot edit another admin's data
+  const [target] = await db
+    .select({ role: userTable.role })
+    .from(userTable)
+    .where(eq(userTable.id, targetUserId))
+    .limit(1);
+
+  if (!target) return { error: "User not found." };
+  if (target.role === "admin" && targetUserId !== admin.id) {
+    return { error: "Cannot edit another admin user." };
+  }
+
+  try {
+    await updateUserAdmin(targetUserId, { name, email, role });
+    return { success: true };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Failed to update user.";
+    return { error: msg };
+  }
+}
+
+export async function deleteUserAsAdminAction(
+  targetUserId: string,
+): Promise<AdminResult> {
+  const admin = await requireAdmin();
+  if (!admin) return { error: "Unauthorized." };
+
+  if (targetUserId === admin.id) {
+    return { error: "You cannot delete your own account." };
+  }
+
+  const [target] = await db
+    .select({ role: userTable.role })
+    .from(userTable)
+    .where(eq(userTable.id, targetUserId))
+    .limit(1);
+
+  if (!target) return { error: "User not found." };
+  if (target.role === "admin") {
+    return { error: "Cannot delete another admin user." };
+  }
+
+  try {
+    await deleteUserAndData(targetUserId);
+    return { success: true };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Failed to delete user.";
+    return { error: msg };
+  }
+}
+
+export async function sendEmailAction(
+  recipients: string[],
+  subject: string,
+  message: string,
+): Promise<AdminResult> {
+  const admin = await requireAdmin();
+  if (!admin) return { error: "Unauthorized." };
+
+  if (!recipients.length) return { error: "At least one recipient is required." };
+  if (!subject.trim()) return { error: "Subject is required." };
+  if (!message.trim()) return { error: "Message is required." };
+
+  try {
+    const resend = new Resend(process.env.RESEND_API_KEY);
+    await resend.emails.send({
+      from: process.env.RESEND_FROM_EMAIL ?? "onboarding@resend.dev",
+      to: recipients,
+      subject,
+      html: `
+        <div style="font-family: sans-serif; max-width: 560px; margin: 0 auto;">
+          <h2 style="color: #032147;">Message from Bird Cage Admin</h2>
+          <div style="white-space: pre-wrap; font-size: 0.95rem; color: #333; line-height: 1.6;">${message}</div>
+          <p style="color: #888888; font-size: 0.8rem; margin-top: 2rem;">This message was sent by an administrator of Bird Cage.</p>
+        </div>
+      `,
+    });
+    return { success: true };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Failed to send email.";
+    return { error: msg };
+  }
+}

--- a/src/app/dashboard/admin/users/page.module.css
+++ b/src/app/dashboard/admin/users/page.module.css
@@ -1,0 +1,42 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-bg-light);
+}
+
+.header {
+  background: var(--color-bg-white);
+  border-bottom: 1px solid var(--color-border-medium);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: var(--color-primary-blue);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+}
+
+.count {
+  margin-left: auto;
+  font-size: 0.85rem;
+  color: var(--color-text-gray);
+  font-weight: 500;
+}
+
+.main {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}

--- a/src/app/dashboard/admin/users/page.tsx
+++ b/src/app/dashboard/admin/users/page.tsx
@@ -1,0 +1,25 @@
+import { requireAdminAuth } from "@/lib/session";
+import { getAllUsers } from "@/lib/dal/users";
+import Link from "next/link";
+import AdminUsersList from "@/components/AdminUsersList";
+import styles from "./page.module.css";
+
+export default async function AdminUsersPage() {
+  const { dbUser } = await requireAdminAuth();
+  const users = await getAllUsers();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard/profile" className={styles.back}>
+          ← Back to Profile
+        </Link>
+        <h1 className={styles.title}>User Management</h1>
+        <span className={styles.count}>{users.length} users</span>
+      </header>
+      <main className={styles.main}>
+        <AdminUsersList users={users} currentUserId={dbUser.id} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/page.module.css
+++ b/src/app/dashboard/profile/page.module.css
@@ -32,4 +32,49 @@
   max-width: 560px;
   margin: 2rem auto;
   padding: 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.adminSection {
+  background: var(--color-bg-white);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-medium);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.adminTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+}
+
+.adminHint {
+  font-size: 0.875rem;
+  color: var(--color-text-gray);
+}
+
+.adminBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-primary-navy);
+  color: white;
+  border: none;
+  padding: 0.65rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  width: fit-content;
+  transition: opacity 0.15s;
+}
+
+.adminBtn:hover {
+  opacity: 0.85;
 }

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -15,6 +15,7 @@ export default async function ProfilePage({
 
   const dbUser = await getUserById(session.user.id);
   const role = dbUser?.role ?? "user";
+  const isAdmin = role === "admin";
 
   return (
     <div className={styles.page}>
@@ -31,6 +32,17 @@ export default async function ProfilePage({
           role={role}
           returnTo={returnTo}
         />
+        {isAdmin && (
+          <div className={styles.adminSection}>
+            <h2 className={styles.adminTitle}>Administration</h2>
+            <p className={styles.adminHint}>
+              Manage users, send emails, and perform admin tasks.
+            </p>
+            <Link href="/dashboard/admin/users" className={styles.adminBtn}>
+              Admin Management
+            </Link>
+          </div>
+        )}
       </main>
     </div>
   );

--- a/src/components/AdminUserEditForm.module.css
+++ b/src/components/AdminUserEditForm.module.css
@@ -1,0 +1,144 @@
+.form {
+  background: var(--color-bg-white);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-medium);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+.section {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-bottom: 1px solid var(--color-border-medium);
+}
+
+.section:last-of-type {
+  border-bottom: none;
+}
+
+.sectionTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  margin-bottom: 0.25rem;
+}
+
+.readOnlyNote {
+  font-size: 0.85rem;
+  color: var(--color-text-gray);
+  background: var(--color-bg-light);
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: 0.6rem 0.9rem;
+  margin-bottom: 0.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text-gray);
+}
+
+.input {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  transition: border-color 0.15s;
+  max-width: 420px;
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary-blue);
+}
+
+.inputReadOnly {
+  background: var(--color-bg-hover);
+  color: var(--color-text-gray);
+  cursor: default;
+}
+
+.inputReadOnly:focus {
+  border-color: var(--color-border-light);
+}
+
+.select {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  font-size: 0.95rem;
+  max-width: 420px;
+  background: var(--color-bg-white);
+  transition: border-color 0.15s;
+}
+
+.select:focus {
+  outline: none;
+  border-color: var(--color-primary-blue);
+}
+
+.error {
+  color: var(--color-error);
+  font-size: 0.875rem;
+  padding: 0 1.5rem;
+}
+
+.successMsg {
+  color: var(--color-success);
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0 1.5rem;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0 1.5rem 1.5rem;
+}
+
+.cancelBtn {
+  background: none;
+  border: 1px solid var(--color-border-light);
+  padding: 0.6rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  color: var(--color-text-medium);
+  cursor: pointer;
+}
+
+.cancelBtn:hover {
+  background: var(--color-bg-hover);
+}
+
+.saveBtn {
+  background: var(--color-primary-purple);
+  color: white;
+  border: none;
+  padding: 0.6rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.saveBtn:hover:not(:disabled) {
+  background: var(--color-purple-hover);
+}
+
+.saveBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/components/AdminUserEditForm.tsx
+++ b/src/components/AdminUserEditForm.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState, startTransition } from "react";
+import { useRouter } from "next/navigation";
+import { updateUserAsAdminAction } from "@/app/dashboard/admin/users/actions";
+import type { User } from "@/lib/dal/users";
+import styles from "./AdminUserEditForm.module.css";
+
+interface Props {
+  targetUser: User;
+  currentUserId: string;
+  returnTo?: string;
+}
+
+export default function AdminUserEditForm({
+  targetUser,
+  currentUserId,
+  returnTo = "/dashboard/admin/users",
+}: Props) {
+  const router = useRouter();
+  const isReadOnly = targetUser.role === "admin" && targetUser.id !== currentUserId;
+
+  const [name, setName] = useState(targetUser.name);
+  const [email, setEmail] = useState(targetUser.email);
+  const [role, setRole] = useState<"user" | "admin">(targetUser.role);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  function handleSubmit(e: React.SubmitEvent) {
+    e.preventDefault();
+    if (isReadOnly) return;
+
+    setError("");
+    setSuccess(false);
+    setSaving(true);
+
+    startTransition(async () => {
+      const result = await updateUserAsAdminAction(
+        targetUser.id,
+        name,
+        email,
+        role,
+      );
+      setSaving(false);
+      if ("error" in result) {
+        setError(result.error);
+      } else {
+        setSuccess(true);
+        setTimeout(() => router.push(returnTo), 800);
+      }
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form}>
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>User Information</h2>
+
+        {isReadOnly && (
+          <p className={styles.readOnlyNote}>
+            This user is an admin. Their profile is read-only.
+          </p>
+        )}
+
+        <div className={styles.field}>
+          <label htmlFor="name" className={styles.label}>
+            Name
+          </label>
+          <input
+            id="name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={`${styles.input} ${isReadOnly ? styles.inputReadOnly : ""}`}
+            readOnly={isReadOnly}
+            required={!isReadOnly}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label htmlFor="email" className={styles.label}>
+            Email Address
+          </label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={`${styles.input} ${isReadOnly ? styles.inputReadOnly : ""}`}
+            readOnly={isReadOnly}
+            required={!isReadOnly}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label htmlFor="role" className={styles.label}>
+            Role
+          </label>
+          {isReadOnly ? (
+            <input
+              id="role"
+              type="text"
+              value={role}
+              readOnly
+              className={`${styles.input} ${styles.inputReadOnly}`}
+            />
+          ) : (
+            <select
+              id="role"
+              value={role}
+              onChange={(e) => setRole(e.target.value as "user" | "admin")}
+              className={styles.select}
+            >
+              <option value="user">User</option>
+              <option value="admin">Admin</option>
+            </select>
+          )}
+        </div>
+      </section>
+
+      {error && <p className={styles.error}>{error}</p>}
+      {success && (
+        <p className={styles.successMsg}>User updated successfully!</p>
+      )}
+
+      <div className={styles.actions}>
+        <button
+          type="button"
+          onClick={() => router.push(returnTo)}
+          className={styles.cancelBtn}
+        >
+          Cancel
+        </button>
+        {!isReadOnly && (
+          <button
+            type="submit"
+            disabled={saving}
+            className={styles.saveBtn}
+          >
+            {saving ? "Saving…" : "Save Changes"}
+          </button>
+        )}
+      </div>
+    </form>
+  );
+}

--- a/src/components/AdminUsersList.module.css
+++ b/src/components/AdminUsersList.module.css
@@ -1,0 +1,246 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.tableWrapper {
+  background: var(--color-bg-white);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-medium);
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.table th {
+  background: var(--color-bg-light);
+  color: var(--color-text-gray);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border-medium);
+}
+
+.table td {
+  padding: 0.85rem 1rem;
+  color: var(--color-text-body);
+  border-bottom: 1px solid var(--color-border-light);
+  vertical-align: middle;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr:hover {
+  background: var(--color-bg-hover);
+}
+
+.roleBadge {
+  display: inline-flex;
+  align-items: center;
+  background: var(--color-bg-purple-light);
+  color: var(--color-primary-purple);
+  border: 1px solid var(--color-primary-purple);
+  border-radius: 20px;
+  padding: 0.15rem 0.75rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.roleBadge.user {
+  background: var(--color-bg-blue-light, #e8f4fb);
+  color: var(--color-primary-blue);
+  border-color: var(--color-primary-blue);
+}
+
+.actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.editBtn {
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--color-primary-blue);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-primary-blue);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.editBtn:hover {
+  background: var(--color-primary-blue);
+  color: white;
+}
+
+.deleteBtn {
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--color-error);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-error);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.deleteBtn:hover {
+  background: var(--color-error);
+  color: white;
+}
+
+.deleteBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.emailBtn {
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--color-primary-navy);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-primary-navy);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.emailBtn:hover {
+  background: var(--color-primary-navy);
+  color: white;
+}
+
+/* Email Compose Section */
+.emailSection {
+  background: var(--color-bg-white);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-medium);
+  overflow: hidden;
+}
+
+.emailHeader {
+  background: var(--color-bg-light);
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--color-border-medium);
+}
+
+.emailTitle {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+}
+
+.emailBody {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-text-gray);
+}
+
+.select,
+.input {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  transition: border-color 0.15s;
+  max-width: 480px;
+  background: var(--color-bg-white);
+}
+
+.select:focus,
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary-blue);
+}
+
+.textarea {
+  padding: 0.55rem 0.75rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  transition: border-color 0.15s;
+  resize: vertical;
+  min-height: 120px;
+  font-family: inherit;
+}
+
+.textarea:focus {
+  outline: none;
+  border-color: var(--color-primary-blue);
+}
+
+.emailActions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.sendBtn {
+  background: var(--color-primary-purple);
+  color: white;
+  border: none;
+  padding: 0.6rem 1.5rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.sendBtn:hover:not(:disabled) {
+  background: var(--color-purple-hover);
+}
+
+.sendBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.successMsg {
+  color: var(--color-success);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.errorMsg {
+  color: var(--color-error);
+  font-size: 0.875rem;
+}
+
+.emptyState {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-gray);
+  font-size: 0.95rem;
+}

--- a/src/components/AdminUsersList.tsx
+++ b/src/components/AdminUsersList.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, startTransition } from "react";
+import { useRouter } from "next/navigation";
+import ConfirmDialog from "@/components/ConfirmDialog";
+import {
+  deleteUserAsAdminAction,
+  sendEmailAction,
+} from "@/app/dashboard/admin/users/actions";
+import type { User } from "@/lib/dal/users";
+import styles from "./AdminUsersList.module.css";
+
+interface Props {
+  users: User[];
+  currentUserId: string;
+}
+
+export default function AdminUsersList({ users, currentUserId }: Props) {
+  const router = useRouter();
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
+
+  // Email compose state
+  const [emailRecipient, setEmailRecipient] = useState("all");
+  const [emailSubject, setEmailSubject] = useState("");
+  const [emailMessage, setEmailMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [emailResult, setEmailResult] = useState<
+    { success: true } | { error: string } | null
+  >(null);
+
+  function handleDelete(userId: string) {
+    setDeleteTarget(userId);
+  }
+
+  function confirmDelete() {
+    if (!deleteTarget) return;
+    setDeleting(true);
+
+    startTransition(async () => {
+      const result = await deleteUserAsAdminAction(deleteTarget);
+      setDeleting(false);
+      setDeleteTarget(null);
+      if ("success" in result) {
+        router.refresh();
+      } else {
+        alert(result.error);
+      }
+    });
+  }
+
+  function handleEmailUser(email: string) {
+    setEmailRecipient(email);
+    setEmailResult(null);
+    document.getElementById("email-section")?.scrollIntoView({ behavior: "smooth" });
+  }
+
+  function handleSendEmail(e: React.SubmitEvent) {
+    e.preventDefault();
+    setEmailResult(null);
+    setSending(true);
+
+    const recipients =
+      emailRecipient === "all"
+        ? users.map((u) => u.email)
+        : [emailRecipient];
+
+    startTransition(async () => {
+      const result = await sendEmailAction(recipients, emailSubject, emailMessage);
+      setSending(false);
+      setEmailResult(result);
+      if ("success" in result) {
+        setEmailSubject("");
+        setEmailMessage("");
+      }
+    });
+  }
+
+  return (
+    <div className={styles.container}>
+      {/* Users Table */}
+      <div className={styles.tableWrapper}>
+        {users.length === 0 ? (
+          <p className={styles.emptyState}>No users found.</p>
+        ) : (
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Created</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {users.map((u) => {
+                const isCurrentUser = u.id === currentUserId;
+                const isAdmin = u.role === "admin";
+                const canDelete = !isCurrentUser && !isAdmin;
+                const canEdit = !isAdmin || isCurrentUser;
+
+                return (
+                  <tr key={u.id}>
+                    <td>{u.name}</td>
+                    <td>{u.email}</td>
+                    <td>
+                      <span
+                        className={`${styles.roleBadge} ${u.role === "user" ? styles.user : ""}`}
+                      >
+                        {u.role}
+                      </span>
+                    </td>
+                    <td>
+                      {u.createdAt
+                        ? new Date(u.createdAt).toLocaleDateString()
+                        : "—"}
+                    </td>
+                    <td>
+                      <div className={styles.actions}>
+                        {canEdit && (
+                          <button
+                            type="button"
+                            onClick={() =>
+                              router.push(
+                                `/dashboard/admin/users/${u.id}/edit`,
+                              )
+                            }
+                            className={styles.editBtn}
+                          >
+                            Edit
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => handleEmailUser(u.email)}
+                          className={styles.emailBtn}
+                        >
+                          Email
+                        </button>
+                        {canDelete && (
+                          <button
+                            type="button"
+                            onClick={() => handleDelete(u.id)}
+                            disabled={deleting}
+                            className={styles.deleteBtn}
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Email Compose Section */}
+      <section className={styles.emailSection} id="email-section">
+        <div className={styles.emailHeader}>
+          <h2 className={styles.emailTitle}>Send Email</h2>
+        </div>
+        <form onSubmit={handleSendEmail} className={styles.emailBody}>
+          <div className={styles.field}>
+            <label htmlFor="email-recipient" className={styles.label}>
+              Recipient
+            </label>
+            <select
+              id="email-recipient"
+              value={emailRecipient}
+              onChange={(e) => {
+                setEmailRecipient(e.target.value);
+                setEmailResult(null);
+              }}
+              className={styles.select}
+            >
+              <option value="all">All Users ({users.length})</option>
+              {users.map((u) => (
+                <option key={u.id} value={u.email}>
+                  {u.name} &lt;{u.email}&gt;
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="email-subject" className={styles.label}>
+              Subject
+            </label>
+            <input
+              id="email-subject"
+              type="text"
+              value={emailSubject}
+              onChange={(e) => {
+                setEmailSubject(e.target.value);
+                setEmailResult(null);
+              }}
+              className={styles.input}
+              required
+              placeholder="Email subject"
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="email-message" className={styles.label}>
+              Message
+            </label>
+            <textarea
+              id="email-message"
+              value={emailMessage}
+              onChange={(e) => {
+                setEmailMessage(e.target.value);
+                setEmailResult(null);
+              }}
+              className={styles.textarea}
+              required
+              placeholder="Write your message here…"
+            />
+          </div>
+
+          <div className={styles.emailActions}>
+            <button
+              type="submit"
+              disabled={sending}
+              className={styles.sendBtn}
+            >
+              {sending ? "Sending…" : "Send Email"}
+            </button>
+            {emailResult &&
+              ("success" in emailResult ? (
+                <span className={styles.successMsg}>Email sent successfully!</span>
+              ) : (
+                <span className={styles.errorMsg}>{emailResult.error}</span>
+              ))}
+          </div>
+        </form>
+      </section>
+
+      <ConfirmDialog
+        open={deleteTarget !== null}
+        message="Delete this user and all their data? This cannot be undone."
+        onConfirm={confirmDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/src/lib/dal/users.ts
+++ b/src/lib/dal/users.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
-import { user as userTable } from "@/db/schema";
+import { user as userTable, birdingEvents, birdEntries } from "@/db/schema";
 
 export type User = typeof userTable.$inferSelect;
 
@@ -13,4 +13,44 @@ export async function getUserById(userId: string): Promise<User | null> {
     .limit(1);
 
   return row ?? null;
+}
+
+/** Fetch all users ordered by creation date (admin only). */
+export async function getAllUsers(): Promise<User[]> {
+  return db.select().from(userTable).orderBy(userTable.createdAt);
+}
+
+/** Update name, email, and role for a user (admin only). */
+export async function updateUserAdmin(
+  userId: string,
+  data: { name: string; email: string; role: "user" | "admin" },
+): Promise<void> {
+  await db
+    .update(userTable)
+    .set({ name: data.name, email: data.email, role: data.role })
+    .where(eq(userTable.id, userId));
+}
+
+/**
+ * Delete a user and all their data (admin only).
+ * Cascades: bird_entries are deleted via eventId cascade,
+ * sessions and accounts are deleted via userId cascade on user delete.
+ */
+export async function deleteUserAndData(userId: string): Promise<void> {
+  // Collect photo paths to clean up
+  const birds = await db
+    .select({ photoPath: birdEntries.photoPath })
+    .from(birdEntries)
+    .innerJoin(birdingEvents, eq(birdEntries.eventId, birdingEvents.id))
+    .where(eq(birdingEvents.userId, userId));
+
+  // Delete birding events (bird_entries cascade via eventId)
+  await db.delete(birdingEvents).where(eq(birdingEvents.userId, userId));
+
+  // Delete the user (sessions/accounts cascade via userId)
+  await db.delete(userTable).where(eq(userTable.id, userId));
+
+  // Clean up photo files after DB records removed
+  const { deleteUploadedFile } = await import("@/lib/uploads");
+  await Promise.all(birds.map((b) => deleteUploadedFile(b.photoPath)));
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,9 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
 import { auth } from "./auth";
+import { db } from "../db";
+import { user as userTable } from "../db/schema";
 
 /** Returns the current session user, or redirects to /login. */
 export async function requireAuth() {
@@ -24,4 +27,26 @@ export async function requireVerifiedAuth() {
 /** Returns the current session user, or null. */
 export async function getSession() {
   return auth.api.getSession({ headers: await headers() });
+}
+
+/**
+ * Returns the current session user and their DB record.
+ * Redirects to /login if unauthenticated.
+ * Redirects to /verify-email if email is not verified.
+ * Redirects to /dashboard if the user is not an admin.
+ */
+export async function requireAdminAuth() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+  if (!session.user.emailVerified) redirect("/verify-email");
+
+  const [dbUser] = await db
+    .select()
+    .from(userTable)
+    .where(eq(userTable.id, session.user.id))
+    .limit(1);
+
+  if (!dbUser || dbUser.role !== "admin") redirect("/dashboard");
+
+  return { session, dbUser };
 }

--- a/src/tests/unit/adminUsers.test.ts
+++ b/src/tests/unit/adminUsers.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+
+// ── Admin action validation logic (mirrors actions.ts) ──────────────────────
+
+function validateUpdateUser(
+  name: string,
+  email: string,
+  role: string,
+): string | null {
+  if (!name.trim()) return "Name is required.";
+  if (!email.trim()) return "Email is required.";
+  if (role !== "user" && role !== "admin") return "Invalid role.";
+  return null;
+}
+
+describe("validateUpdateUser", () => {
+  it("returns error when name is empty", () => {
+    expect(validateUpdateUser("", "a@b.com", "user")).toBe("Name is required.");
+  });
+
+  it("returns error when name is only whitespace", () => {
+    expect(validateUpdateUser("   ", "a@b.com", "user")).toBe("Name is required.");
+  });
+
+  it("returns error when email is empty", () => {
+    expect(validateUpdateUser("Alice", "", "user")).toBe("Email is required.");
+  });
+
+  it("returns error when role is invalid", () => {
+    expect(validateUpdateUser("Alice", "a@b.com", "superuser")).toBe("Invalid role.");
+  });
+
+  it("returns null for valid user data", () => {
+    expect(validateUpdateUser("Alice", "alice@example.com", "user")).toBeNull();
+  });
+
+  it("returns null for valid admin data", () => {
+    expect(validateUpdateUser("Bob", "bob@example.com", "admin")).toBeNull();
+  });
+});
+
+// ── Admin delete guards ──────────────────────────────────────────────────────
+
+function canDeleteUser(
+  currentUserId: string,
+  targetUserId: string,
+  targetRole: string,
+): string | null {
+  if (targetUserId === currentUserId) return "You cannot delete your own account.";
+  if (targetRole === "admin") return "Cannot delete another admin user.";
+  return null;
+}
+
+describe("canDeleteUser", () => {
+  it("blocks self-deletion", () => {
+    expect(canDeleteUser("u1", "u1", "admin")).toBe(
+      "You cannot delete your own account.",
+    );
+  });
+
+  it("blocks deleting another admin", () => {
+    expect(canDeleteUser("u1", "u2", "admin")).toBe(
+      "Cannot delete another admin user.",
+    );
+  });
+
+  it("allows deleting a regular user", () => {
+    expect(canDeleteUser("u1", "u2", "user")).toBeNull();
+  });
+});
+
+// ── Admin edit guards ────────────────────────────────────────────────────────
+
+function canEditUser(
+  currentUserId: string,
+  targetUserId: string,
+  targetRole: string,
+): boolean {
+  // Can edit self (even if admin), and can edit non-admin users
+  if (targetRole === "admin" && targetUserId !== currentUserId) return false;
+  return true;
+}
+
+describe("canEditUser", () => {
+  it("allows editing own admin profile", () => {
+    expect(canEditUser("u1", "u1", "admin")).toBe(true);
+  });
+
+  it("blocks editing another admin", () => {
+    expect(canEditUser("u1", "u2", "admin")).toBe(false);
+  });
+
+  it("allows editing a regular user", () => {
+    expect(canEditUser("u1", "u2", "user")).toBe(true);
+  });
+});
+
+// ── Email validation ─────────────────────────────────────────────────────────
+
+function validateSendEmail(
+  recipients: string[],
+  subject: string,
+  message: string,
+): string | null {
+  if (!recipients.length) return "At least one recipient is required.";
+  if (!subject.trim()) return "Subject is required.";
+  if (!message.trim()) return "Message is required.";
+  return null;
+}
+
+describe("validateSendEmail", () => {
+  it("returns error when no recipients", () => {
+    expect(validateSendEmail([], "Subject", "Hello")).toBe(
+      "At least one recipient is required.",
+    );
+  });
+
+  it("returns error when subject is empty", () => {
+    expect(validateSendEmail(["a@b.com"], "", "Hello")).toBe("Subject is required.");
+  });
+
+  it("returns error when subject is whitespace", () => {
+    expect(validateSendEmail(["a@b.com"], "   ", "Hello")).toBe("Subject is required.");
+  });
+
+  it("returns error when message is empty", () => {
+    expect(validateSendEmail(["a@b.com"], "Hi", "")).toBe("Message is required.");
+  });
+
+  it("returns null for valid email data", () => {
+    expect(
+      validateSendEmail(["a@b.com", "c@d.com"], "Hello", "This is a message."),
+    ).toBeNull();
+  });
+});
+
+// ── Role badge display ───────────────────────────────────────────────────────
+
+function getRoleBadgeClass(role: string): string {
+  return role === "user" ? "badge-user" : "badge-admin";
+}
+
+describe("getRoleBadgeClass", () => {
+  it("returns user class for user role", () => {
+    expect(getRoleBadgeClass("user")).toBe("badge-user");
+  });
+
+  it("returns admin class for admin role", () => {
+    expect(getRoleBadgeClass("admin")).toBe("badge-admin");
+  });
+});


### PR DESCRIPTION
- Add getAllUsers, updateUserAdmin, deleteUserAndData DAL functions
- Add requireAdminAuth() helper to session.ts for admin-only routes
- Create /dashboard/admin/users page with user table (name, email, role, date, actions)
- Create /dashboard/admin/users/[id]/edit page for editing user name/email/role
- Add AdminUsersList client component with delete confirmation and email compose UI
- Add AdminUserEditForm client component (read-only for other admins)
- Add server actions: updateUserAsAdminAction, deleteUserAsAdminAction, sendEmailAction (Resend)
- Show "Admin Management" button on profile page for admin users
- Role-based access: all admin routes redirect non-admins to /dashboard
- Add 19 unit tests covering DAL guards, action validation, and role badge logic (87 total)