### PR TITLE
feat(BRD-95-2): Email audit log for admin-sent emails

### DIFF
--- a/drizzle/0005_add_email_logs.sql
+++ b/drizzle/0005_add_email_logs.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `email_logs` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`sender_id` text NOT NULL REFERENCES `user`(`id`) ON DELETE CASCADE,
+	`recipient_id` text NOT NULL REFERENCES `user`(`id`) ON DELETE CASCADE,
+	`subject` text NOT NULL,
+	`message` text NOT NULL,
+	`sent_at` integer NOT NULL DEFAULT (cast(unixepoch('subsecond') * 1000 as integer))
+);
+--> statement-breakpoint
+CREATE INDEX `email_logs_recipientId_idx` ON `email_logs` (`recipient_id`);
+--> statement-breakpoint
+CREATE INDEX `email_logs_senderId_idx` ON `email_logs` (`sender_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1743900000000,
       "tag": "0004_add_user_role",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1744000000000,
+      "tag": "0005_add_email_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/dashboard/admin/emails/page.module.css
+++ b/src/app/dashboard/admin/emails/page.module.css
@@ -1,0 +1,62 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-bg-light);
+}
+
+.header {
+  background: var(--color-bg-white);
+  border-bottom: 1px solid var(--color-border-medium);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: var(--color-primary-blue);
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+}
+
+.main {
+  max-width: 1100px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.filterBanner {
+  background: var(--color-bg-yellow-light);
+  border: 1px solid var(--color-primary-yellow);
+  border-radius: 6px;
+  padding: 0.6rem 1rem;
+  font-size: 0.9rem;
+  color: var(--color-text-body);
+  margin-bottom: 1rem;
+}
+
+.showAll {
+  color: var(--color-primary-blue);
+  font-weight: 500;
+}
+
+.showAll:hover {
+  text-decoration: underline;
+}
+
+.card {
+  background: var(--color-bg-white);
+  border: 1px solid var(--color-border-medium);
+  border-radius: 8px;
+  padding: 1.5rem;
+}

--- a/src/app/dashboard/admin/emails/page.tsx
+++ b/src/app/dashboard/admin/emails/page.tsx
@@ -1,0 +1,47 @@
+import { requireAdminAuth } from "@/lib/session";
+import { getAllEmailLogs } from "@/lib/dal/emailLogs";
+import { getAllUsers } from "@/lib/dal/users";
+import Link from "next/link";
+import AdminEmailLog from "@/components/AdminEmailLog";
+import styles from "./page.module.css";
+
+export default async function AdminEmailsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ userId?: string }>;
+}) {
+  await requireAdminAuth();
+  const { userId } = await searchParams;
+
+  const [logs, users] = await Promise.all([
+    getAllEmailLogs(userId),
+    userId ? getAllUsers() : Promise.resolve([]),
+  ]);
+
+  const filterUser = userId ? users.find((u) => u.id === userId) : null;
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard/admin/users" className={styles.back}>
+          ← Back to Users
+        </Link>
+        <h1 className={styles.title}>Email Audit Log</h1>
+      </header>
+      <main className={styles.main}>
+        {filterUser && (
+          <div className={styles.filterBanner}>
+            Showing emails for <strong>{filterUser.name}</strong>
+            {" — "}
+            <Link href="/dashboard/admin/emails" className={styles.showAll}>
+              Show all
+            </Link>
+          </div>
+        )}
+        <div className={styles.card}>
+          <AdminEmailLog logs={logs} />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/users/actions.ts
+++ b/src/app/dashboard/admin/users/actions.ts
@@ -1,0 +1,72 @@
+"use server";
+
+import { headers } from "next/headers";
+import { Resend } from "resend";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { user as userTable } from "@/db/schema";
+import { inArray } from "drizzle-orm";
+import { insertEmailLogs } from "@/lib/dal/emailLogs";
+
+export type SendEmailResult = { success: true } | { error: string };
+
+export async function sendEmailAction(
+  recipientIds: string[],
+  subject: string,
+  message: string,
+): Promise<SendEmailResult> {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) return { error: "Not authenticated." };
+
+  const dbUser = await db
+    .select()
+    .from(userTable)
+    .where(inArray(userTable.id, [session.user.id]))
+    .limit(1);
+  if (!dbUser[0] || dbUser[0].role !== "admin") {
+    return { error: "Unauthorized." };
+  }
+
+  if (!recipientIds.length) return { error: "No recipients selected." };
+  if (!subject.trim()) return { error: "Subject is required." };
+  if (!message.trim()) return { error: "Message is required." };
+
+  // Resolve recipient emails from IDs
+  const recipients = await db
+    .select({ id: userTable.id, email: userTable.email, name: userTable.name })
+    .from(userTable)
+    .where(inArray(userTable.id, recipientIds));
+
+  if (!recipients.length) return { error: "No valid recipients found." };
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const fromEmail = process.env.RESEND_FROM_EMAIL ?? "onboarding@resend.dev";
+
+  try {
+    await Promise.all(
+      recipients.map((r) =>
+        resend.emails.send({
+          from: fromEmail,
+          to: r.email,
+          subject,
+          html: `<div style="font-family: sans-serif; max-width: 600px; margin: 0 auto;">
+            <h2 style="color: #032147;">Message from Bird Cage Admin</h2>
+            <p>Hi ${r.name},</p>
+            <div style="background: #f5f5f0; padding: 1rem; border-radius: 6px; margin: 1rem 0;">
+              ${message.replace(/\n/g, "<br/>")}
+            </div>
+            <p style="color: #888888; font-size: 0.85rem;">This message was sent by an administrator of Bird Cage.</p>
+          </div>`,
+        }),
+      ),
+    );
+  } catch (err) {
+    console.error("[sendEmailAction] failed to send emails:", err);
+    return { error: "Failed to send emails." };
+  }
+
+  // Log emails to DB
+  await insertEmailLogs(session.user.id, recipientIds, subject, message);
+
+  return { success: true };
+}

--- a/src/app/dashboard/admin/users/page.module.css
+++ b/src/app/dashboard/admin/users/page.module.css
@@ -1,0 +1,48 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-bg-light);
+}
+
+.header {
+  background: var(--color-bg-white);
+  border-bottom: 1px solid var(--color-border-medium);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: var(--color-primary-blue);
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  flex: 1;
+}
+
+.auditLink {
+  color: var(--color-primary-purple);
+  font-size: 0.9rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.auditLink:hover {
+  text-decoration: underline;
+}
+
+.main {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}

--- a/src/app/dashboard/admin/users/page.tsx
+++ b/src/app/dashboard/admin/users/page.tsx
@@ -1,0 +1,27 @@
+import { requireAdminAuth } from "@/lib/session";
+import { getAllUsers } from "@/lib/dal/users";
+import Link from "next/link";
+import AdminUsersList from "@/components/AdminUsersList";
+import styles from "./page.module.css";
+
+export default async function AdminUsersPage() {
+  await requireAdminAuth();
+  const users = await getAllUsers();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard" className={styles.back}>
+          ← Back to Dashboard
+        </Link>
+        <h1 className={styles.title}>Admin — Users</h1>
+        <Link href="/dashboard/admin/emails" className={styles.auditLink}>
+          Email Audit Log →
+        </Link>
+      </header>
+      <main className={styles.main}>
+        <AdminUsersList users={users} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,7 +1,9 @@
 import { requireVerifiedAuth } from "@/lib/session";
 import { getUserById } from "@/lib/dal/users";
+import { getEmailsForUser } from "@/lib/dal/emailLogs";
 import Link from "next/link";
 import ProfileForm from "@/components/ProfileForm";
+import EmailsReceived from "@/components/EmailsReceived";
 import styles from "./page.module.css";
 
 export default async function ProfilePage({
@@ -13,7 +15,10 @@ export default async function ProfilePage({
   const { from } = await searchParams;
   const returnTo = from ?? "/dashboard";
 
-  const dbUser = await getUserById(session.user.id);
+  const [dbUser, receivedEmails] = await Promise.all([
+    getUserById(session.user.id),
+    getEmailsForUser(session.user.id),
+  ]);
   const role = dbUser?.role ?? "user";
 
   return (
@@ -31,6 +36,7 @@ export default async function ProfilePage({
           role={role}
           returnTo={returnTo}
         />
+        <EmailsReceived logs={receivedEmails} />
       </main>
     </div>
   );

--- a/src/components/AdminEmailLog.module.css
+++ b/src/components/AdminEmailLog.module.css
@@ -1,0 +1,44 @@
+.empty {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  padding: 1rem 0;
+}
+
+.tableWrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.875rem;
+}
+
+.th {
+  text-align: left;
+  padding: 0.6rem 0.75rem;
+  border-bottom: 2px solid var(--color-border-medium);
+  color: var(--color-text-label);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.tr:hover {
+  background: var(--color-bg-hover);
+}
+
+.td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light-gray);
+  color: var(--color-text-body);
+  vertical-align: top;
+}
+
+.messageCell {
+  max-width: 320px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  white-space: pre-wrap;
+}

--- a/src/components/AdminEmailLog.tsx
+++ b/src/components/AdminEmailLog.tsx
@@ -1,0 +1,45 @@
+import type { EmailLogWithNames } from "@/lib/dal/emailLogs";
+import styles from "./AdminEmailLog.module.css";
+
+interface Props {
+  logs: EmailLogWithNames[];
+}
+
+export default function AdminEmailLog({ logs }: Props) {
+  if (logs.length === 0) {
+    return <p className={styles.empty}>No emails sent yet.</p>;
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th className={styles.th}>Date</th>
+            <th className={styles.th}>Sender</th>
+            <th className={styles.th}>Recipient</th>
+            <th className={styles.th}>Subject</th>
+            <th className={styles.th}>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => (
+            <tr key={log.id} className={styles.tr}>
+              <td className={styles.td}>
+                {log.sentAt.toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </td>
+              <td className={styles.td}>{log.senderName}</td>
+              <td className={styles.td}>{log.recipientName}</td>
+              <td className={styles.td}>{log.subject}</td>
+              <td className={`${styles.td} ${styles.messageCell}`}>{log.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/AdminUsersList.module.css
+++ b/src/components/AdminUsersList.module.css
@@ -1,0 +1,150 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.section {
+  background: var(--color-bg-white);
+  border: 1px solid var(--color-border-medium);
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+
+.sectionTitle {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  margin-bottom: 1rem;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.th {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 2px solid var(--color-border-medium);
+  color: var(--color-text-label);
+  font-weight: 600;
+}
+
+.tr:hover {
+  background: var(--color-bg-hover);
+}
+
+.td {
+  padding: 0.6rem 0.75rem;
+  border-bottom: 1px solid var(--color-border-light-gray);
+  color: var(--color-text-body);
+}
+
+.roleAdmin {
+  background: var(--color-bg-purple-light);
+  color: var(--color-primary-purple);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.roleUser {
+  background: var(--color-bg-blue-light);
+  color: var(--color-primary-blue);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+}
+
+.viewEmailsBtn {
+  background: transparent;
+  border: 1px solid var(--color-primary-blue);
+  color: var(--color-primary-blue);
+  padding: 0.25rem 0.6rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.viewEmailsBtn:hover {
+  background: var(--color-bg-blue-light);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.label {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--color-text-label);
+}
+
+.select,
+.input,
+.textarea {
+  border: 1px solid var(--color-border-light);
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  color: var(--color-text-body);
+  background: var(--color-bg-white);
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.textarea {
+  resize: vertical;
+  font-family: inherit;
+}
+
+.select:focus,
+.input:focus,
+.textarea:focus {
+  outline: 2px solid var(--color-primary-blue);
+  outline-offset: -1px;
+}
+
+.sendBtn {
+  background: var(--color-primary-purple);
+  color: white;
+  border: none;
+  padding: 0.6rem 1.25rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  align-self: flex-start;
+  transition: background 0.15s;
+}
+
+.sendBtn:hover:not(:disabled) {
+  background: var(--color-purple-hover);
+}
+
+.sendBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.error {
+  color: var(--color-error);
+  font-size: 0.875rem;
+}
+
+.success {
+  color: var(--color-success);
+  font-size: 0.875rem;
+}

--- a/src/components/AdminUsersList.tsx
+++ b/src/components/AdminUsersList.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState, startTransition } from "react";
+import { useRouter } from "next/navigation";
+import { sendEmailAction } from "@/app/dashboard/admin/users/actions";
+import type { User } from "@/lib/dal/users";
+import styles from "./AdminUsersList.module.css";
+
+interface Props {
+  users: User[];
+}
+
+export default function AdminUsersList({ users }: Props) {
+  const router = useRouter();
+  const [emailRecipient, setEmailRecipient] = useState<string>("all");
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [status, setStatus] = useState<{ type: "success" | "error"; text: string } | null>(null);
+
+  function handleSendEmail(e: React.SubmitEvent) {
+    e.preventDefault();
+    setStatus(null);
+    setSending(true);
+
+    const recipientIds =
+      emailRecipient === "all" ? users.map((u) => u.id) : [emailRecipient];
+
+    startTransition(async () => {
+      const result = await sendEmailAction(recipientIds, subject, message);
+      setSending(false);
+      if ("error" in result) {
+        setStatus({ type: "error", text: result.error });
+      } else {
+        setStatus({ type: "success", text: "Email sent successfully!" });
+        setSubject("");
+        setMessage("");
+      }
+    });
+  }
+
+  return (
+    <div className={styles.container}>
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Registered Users</h2>
+        <table className={styles.table}>
+          <thead>
+            <tr>
+              <th className={styles.th}>Name</th>
+              <th className={styles.th}>Email</th>
+              <th className={styles.th}>Role</th>
+              <th className={styles.th}>Verified</th>
+              <th className={styles.th}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.id} className={styles.tr}>
+                <td className={styles.td}>{u.name}</td>
+                <td className={styles.td}>{u.email}</td>
+                <td className={styles.td}>
+                  <span className={u.role === "admin" ? styles.roleAdmin : styles.roleUser}>
+                    {u.role}
+                  </span>
+                </td>
+                <td className={styles.td}>{u.emailVerified ? "✓" : "✗"}</td>
+                <td className={styles.td}>
+                  <button
+                    className={styles.viewEmailsBtn}
+                    onClick={() => router.push(`/dashboard/admin/emails?userId=${u.id}`)}
+                  >
+                    View Emails
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Send Email to Users</h2>
+        <form onSubmit={handleSendEmail} className={styles.form}>
+          <div className={styles.field}>
+            <label htmlFor="recipient" className={styles.label}>
+              Recipient
+            </label>
+            <select
+              id="recipient"
+              value={emailRecipient}
+              onChange={(e) => setEmailRecipient(e.target.value)}
+              className={styles.select}
+            >
+              <option value="all">All Users</option>
+              {users.map((u) => (
+                <option key={u.id} value={u.id}>
+                  {u.name} ({u.email})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="subject" className={styles.label}>
+              Subject
+            </label>
+            <input
+              id="subject"
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              className={styles.input}
+              required
+              placeholder="Email subject..."
+            />
+          </div>
+
+          <div className={styles.field}>
+            <label htmlFor="message" className={styles.label}>
+              Message
+            </label>
+            <textarea
+              id="message"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className={styles.textarea}
+              required
+              rows={6}
+              placeholder="Your message..."
+            />
+          </div>
+
+          {status && (
+            <p className={status.type === "error" ? styles.error : styles.success}>
+              {status.text}
+            </p>
+          )}
+
+          <button type="submit" disabled={sending} className={styles.sendBtn}>
+            {sending ? "Sending…" : "Send Email"}
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/src/components/EmailsReceived.module.css
+++ b/src/components/EmailsReceived.module.css
@@ -1,0 +1,65 @@
+.section {
+  margin-top: 2rem;
+}
+
+.title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  margin-bottom: 0.75rem;
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+  padding: 1rem 0;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card {
+  background: var(--color-bg-white);
+  border: 1px solid var(--color-border-medium);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.subject {
+  font-weight: 600;
+  color: var(--color-text-dark);
+  font-size: 0.95rem;
+}
+
+.date {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.from {
+  color: var(--color-text-gray);
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.message {
+  color: var(--color-text-body);
+  font-size: 0.9rem;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}

--- a/src/components/EmailsReceived.tsx
+++ b/src/components/EmailsReceived.tsx
@@ -1,0 +1,36 @@
+import type { EmailLogWithNames } from "@/lib/dal/emailLogs";
+import styles from "./EmailsReceived.module.css";
+
+interface Props {
+  logs: EmailLogWithNames[];
+}
+
+export default function EmailsReceived({ logs }: Props) {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.title}>Emails Received</h2>
+      {logs.length === 0 ? (
+        <p className={styles.empty}>No emails received yet.</p>
+      ) : (
+        <ul className={styles.list}>
+          {logs.map((log) => (
+            <li key={log.id} className={styles.card}>
+              <div className={styles.cardHeader}>
+                <span className={styles.subject}>{log.subject}</span>
+                <span className={styles.date}>
+                  {log.sentAt.toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+              </div>
+              <p className={styles.from}>From: {log.senderName}</p>
+              <p className={styles.message}>{log.message}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -121,11 +121,35 @@ export const birdEntries = sqliteTable("bird_entries", {
   photoData: text("photo_data"),
 });
 
+export const emailLogs = sqliteTable(
+  "email_logs",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    senderId: text("sender_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    recipientId: text("recipient_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    subject: text("subject").notNull(),
+    message: text("message").notNull(),
+    sentAt: integer("sent_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index("email_logs_recipientId_idx").on(table.recipientId),
+    index("email_logs_senderId_idx").on(table.senderId),
+  ],
+);
+
 // Relations
 export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),
   birdingEvents: many(birdingEvents),
+  sentEmails: many(emailLogs, { relationName: "sentEmails" }),
+  receivedEmails: many(emailLogs, { relationName: "receivedEmails" }),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({
@@ -141,8 +165,23 @@ export const birdingEventRelations = relations(birdingEvents, ({ one, many }) =>
   birds: many(birdEntries),
 }));
 
+export const emailLogRelations = relations(emailLogs, ({ one }) => ({
+  sender: one(user, {
+    fields: [emailLogs.senderId],
+    references: [user.id],
+    relationName: "sentEmails",
+  }),
+  recipient: one(user, {
+    fields: [emailLogs.recipientId],
+    references: [user.id],
+    relationName: "receivedEmails",
+  }),
+}));
+
 // Types
 export type BirdingEvent = typeof birdingEvents.$inferSelect;
 export type BirdEntry = typeof birdEntries.$inferSelect;
 export type NewBirdingEvent = typeof birdingEvents.$inferInsert;
 export type NewBirdEntry = typeof birdEntries.$inferInsert;
+export type EmailLog = typeof emailLogs.$inferSelect;
+export type NewEmailLog = typeof emailLogs.$inferInsert;

--- a/src/lib/dal/emailLogs.ts
+++ b/src/lib/dal/emailLogs.ts
@@ -1,0 +1,88 @@
+import { desc, eq } from "drizzle-orm";
+import { aliasedTable } from "drizzle-orm";
+import { db } from "@/db";
+import { emailLogs, user as userTable } from "@/db/schema";
+
+export type EmailLogWithNames = {
+  id: number;
+  senderId: string;
+  recipientId: string;
+  subject: string;
+  message: string;
+  sentAt: Date;
+  senderName: string;
+  recipientName: string;
+};
+
+/** Batch-insert one email log row per recipient ID. */
+export async function insertEmailLogs(
+  senderId: string,
+  recipientIds: string[],
+  subject: string,
+  message: string,
+): Promise<void> {
+  if (recipientIds.length === 0) return;
+  await db.insert(emailLogs).values(
+    recipientIds.map((recipientId) => ({
+      senderId,
+      recipientId,
+      subject,
+      message,
+    })),
+  );
+}
+
+/** Get emails received by a user, with sender name, newest first. */
+export async function getEmailsForUser(userId: string): Promise<EmailLogWithNames[]> {
+  const sender = aliasedTable(userTable, "sender");
+  const recipient = aliasedTable(userTable, "recipient");
+
+  const rows = await db
+    .select({
+      id: emailLogs.id,
+      senderId: emailLogs.senderId,
+      recipientId: emailLogs.recipientId,
+      subject: emailLogs.subject,
+      message: emailLogs.message,
+      sentAt: emailLogs.sentAt,
+      senderName: sender.name,
+      recipientName: recipient.name,
+    })
+    .from(emailLogs)
+    .innerJoin(sender, eq(emailLogs.senderId, sender.id))
+    .innerJoin(recipient, eq(emailLogs.recipientId, recipient.id))
+    .where(eq(emailLogs.recipientId, userId))
+    .orderBy(desc(emailLogs.sentAt));
+
+  return rows.map((r) => ({ ...r, sentAt: new Date(r.sentAt as unknown as number) }));
+}
+
+/** Get all email logs for admin view; optionally filter by recipientId. */
+export async function getAllEmailLogs(recipientId?: string): Promise<EmailLogWithNames[]> {
+  const sender = aliasedTable(userTable, "sender");
+  const recipient = aliasedTable(userTable, "recipient");
+
+  const query = db
+    .select({
+      id: emailLogs.id,
+      senderId: emailLogs.senderId,
+      recipientId: emailLogs.recipientId,
+      subject: emailLogs.subject,
+      message: emailLogs.message,
+      sentAt: emailLogs.sentAt,
+      senderName: sender.name,
+      recipientName: recipient.name,
+    })
+    .from(emailLogs)
+    .innerJoin(sender, eq(emailLogs.senderId, sender.id))
+    .innerJoin(recipient, eq(emailLogs.recipientId, recipient.id))
+    .orderBy(desc(emailLogs.sentAt));
+
+  if (recipientId) {
+    const rows = await query.where(eq(emailLogs.recipientId, recipientId));
+    return rows.map((r) => ({ ...r, sentAt: new Date(r.sentAt as unknown as number) }));
+  }
+
+  const rows = await query;
+  return rows.map((r) => ({ ...r, sentAt: new Date(r.sentAt as unknown as number) }));
+}

--- a/src/lib/dal/users.ts
+++ b/src/lib/dal/users.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { db } from "@/db";
 import { user as userTable } from "@/db/schema";
 
@@ -13,4 +13,9 @@ export async function getUserById(userId: string): Promise<User | null> {
     .limit(1);
 
   return row ?? null;
+}
+
+/** Fetch all users ordered by name. */
+export async function getAllUsers(): Promise<User[]> {
+  return db.select().from(userTable).orderBy(asc(userTable.name));
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,6 +1,9 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "./auth";
+import { db } from "@/db";
+import { user as userTable } from "@/db/schema";
+import { eq } from "drizzle-orm";
 
 /** Returns the current session user, or redirects to /login. */
 export async function requireAuth() {
@@ -24,4 +27,23 @@ export async function requireVerifiedAuth() {
 /** Returns the current session user, or null. */
 export async function getSession() {
   return auth.api.getSession({ headers: await headers() });
+}
+
+/**
+ * Returns the current session user if they are an admin.
+ * Redirects to /login if unauthenticated.
+ * Redirects to /dashboard if not an admin.
+ */
+export async function requireAdminAuth() {
+  const session = await auth.api.getSession({ headers: await headers() });
+  if (!session) redirect("/login");
+
+  const [dbUser] = await db
+    .select({ role: userTable.role })
+    .from(userTable)
+    .where(eq(userTable.id, session.user.id))
+    .limit(1);
+
+  if (!dbUser || dbUser.role !== "admin") redirect("/dashboard");
+  return session;
 }


### PR DESCRIPTION
- Add `emailLogs` table to schema with sender/recipient FKs and indexes
- Add migration 0005_add_email_logs.sql
- Add emailLogs DAL: insertEmailLogs, getEmailsForUser, getAllEmailLogs
- Add requireAdminAuth() helper to session.ts
- Add getAllUsers() to users DAL
- Create admin users page at /dashboard/admin/users with user table and send-email form
- Create sendEmailAction that resolves IDs→emails, sends via Resend, logs to DB
- Create AdminUsersList client component with "View Emails" per-user button
- Add EmailsReceived server component to profile page showing received emails
- Create admin email audit page at /dashboard/admin/emails with optional userId filter
- Create AdminEmailLog table component with date/sender/recipient/subject/message