### PR TITLE
feat(BRD-95-2): add email audit log for admin-sent emails

### DIFF
--- a/drizzle/0005_add_email_logs.sql
+++ b/drizzle/0005_add_email_logs.sql
@@ -1,0 +1,14 @@
+CREATE TABLE `email_logs` (
+  `id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+  `sender_id` text NOT NULL,
+  `recipient_id` text NOT NULL,
+  `subject` text NOT NULL,
+  `message` text NOT NULL,
+  `sent_at` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+  FOREIGN KEY (`sender_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade,
+  FOREIGN KEY (`recipient_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `email_logs_recipient_idx` ON `email_logs` (`recipient_id`);
+--> statement-breakpoint
+CREATE INDEX `email_logs_sender_idx` ON `email_logs` (`sender_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1743900000000,
       "tag": "0004_add_user_role",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1744000000000,
+      "tag": "0005_add_email_logs",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -46,6 +46,33 @@ async function main() {
     console.log("role column added successfully");
   }
 
+  // Idempotent schema safety check: ensure email_logs table exists.
+  const emailLogsCheck = await client.execute(
+    "SELECT name FROM sqlite_master WHERE type='table' AND name='email_logs'"
+  );
+  if (emailLogsCheck.rows.length === 0) {
+    console.log("email_logs table missing — applying schema fix");
+    await client.execute(
+      `CREATE TABLE \`email_logs\` (
+        \`id\` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        \`sender_id\` text NOT NULL,
+        \`recipient_id\` text NOT NULL,
+        \`subject\` text NOT NULL,
+        \`message\` text NOT NULL,
+        \`sent_at\` integer DEFAULT (cast(unixepoch('subsecond') * 1000 as integer)) NOT NULL,
+        FOREIGN KEY (\`sender_id\`) REFERENCES \`user\`(\`id\`) ON UPDATE no action ON DELETE cascade,
+        FOREIGN KEY (\`recipient_id\`) REFERENCES \`user\`(\`id\`) ON UPDATE no action ON DELETE cascade
+      )`
+    );
+    await client.execute(
+      "CREATE INDEX `email_logs_recipient_idx` ON `email_logs` (`recipient_id`)"
+    );
+    await client.execute(
+      "CREATE INDEX `email_logs_sender_idx` ON `email_logs` (`sender_id`)"
+    );
+    console.log("email_logs table created successfully");
+  }
+
   await client.close();
 }
 

--- a/src/app/dashboard/admin/emails/page.module.css
+++ b/src/app/dashboard/admin/emails/page.module.css
@@ -28,25 +28,40 @@
   color: var(--color-primary-navy);
 }
 
-.auditLink {
-  color: var(--color-primary-blue);
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-left: auto;
-}
-
-.auditLink:hover {
-  text-decoration: underline;
-}
-
 .count {
+  margin-left: auto;
   font-size: 0.85rem;
   color: var(--color-text-gray);
   font-weight: 500;
 }
 
 .main {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 2rem auto;
   padding: 0 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.filterBanner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: var(--color-bg-blue-light, #e8f4fb);
+  border: 1px solid var(--color-primary-blue);
+  border-radius: 8px;
+  padding: 0.75rem 1.25rem;
+  font-size: 0.9rem;
+  color: var(--color-primary-navy);
+}
+
+.showAll {
+  color: var(--color-primary-blue);
+  font-weight: 500;
+  margin-left: auto;
+}
+
+.showAll:hover {
+  text-decoration: underline;
 }

--- a/src/app/dashboard/admin/emails/page.tsx
+++ b/src/app/dashboard/admin/emails/page.tsx
@@ -1,0 +1,39 @@
+import { requireAdminAuth } from "@/lib/session";
+import { getAllEmailLogs } from "@/lib/dal/emailLogs";
+import Link from "next/link";
+import AdminEmailLog from "@/components/AdminEmailLog";
+import styles from "./page.module.css";
+
+export default async function AdminEmailsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ userId?: string }>;
+}) {
+  await requireAdminAuth();
+  const { userId } = await searchParams;
+  const logs = await getAllEmailLogs(userId);
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard/admin/users" className={styles.back}>
+          ← Back to User Management
+        </Link>
+        <h1 className={styles.title}>Email Audit Log</h1>
+        <span className={styles.count}>{logs.length} emails</span>
+      </header>
+
+      <main className={styles.main}>
+        {userId && (
+          <div className={styles.filterBanner}>
+            <span>Showing emails for one user.</span>
+            <Link href="/dashboard/admin/emails" className={styles.showAll}>
+              Show all →
+            </Link>
+          </div>
+        )}
+        <AdminEmailLog logs={logs} />
+      </main>
+    </div>
+  );
+}

--- a/src/app/dashboard/admin/users/actions.ts
+++ b/src/app/dashboard/admin/users/actions.ts
@@ -2,11 +2,12 @@
 
 import { headers } from "next/headers";
 import { Resend } from "resend";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { user as userTable } from "@/db/schema";
 import { updateUserAdmin, deleteUserAndData } from "@/lib/dal/users";
+import { insertEmailLogs } from "@/lib/dal/emailLogs";
 
 export type AdminResult = { success: true } | { error: string };
 
@@ -90,22 +91,31 @@ export async function deleteUserAsAdminAction(
 }
 
 export async function sendEmailAction(
-  recipients: string[],
+  recipientIds: string[],
   subject: string,
   message: string,
 ): Promise<AdminResult> {
   const admin = await requireAdmin();
   if (!admin) return { error: "Unauthorized." };
 
-  if (!recipients.length) return { error: "At least one recipient is required." };
+  if (!recipientIds.length) return { error: "At least one recipient is required." };
   if (!subject.trim()) return { error: "Subject is required." };
   if (!message.trim()) return { error: "Message is required." };
 
   try {
+    // Resolve emails from IDs
+    const userRows = await db
+      .select({ id: userTable.id, email: userTable.email })
+      .from(userTable)
+      .where(inArray(userTable.id, recipientIds));
+
+    const emails = userRows.map((u) => u.email);
+    if (!emails.length) return { error: "No valid recipients found." };
+
     const resend = new Resend(process.env.RESEND_API_KEY);
     await resend.emails.send({
       from: process.env.RESEND_FROM_EMAIL ?? "onboarding@resend.dev",
-      to: recipients,
+      to: emails,
       subject,
       html: `
         <div style="font-family: sans-serif; max-width: 560px; margin: 0 auto;">
@@ -115,6 +125,8 @@ export async function sendEmailAction(
         </div>
       `,
     });
+
+    await insertEmailLogs(admin.id, recipientIds, subject, message);
     return { success: true };
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Failed to send email.";

--- a/src/app/dashboard/admin/users/page.tsx
+++ b/src/app/dashboard/admin/users/page.tsx
@@ -15,6 +15,9 @@ export default async function AdminUsersPage() {
           ← Back to Profile
         </Link>
         <h1 className={styles.title}>User Management</h1>
+        <Link href="/dashboard/admin/emails" className={styles.auditLink}>
+          Email Audit Log →
+        </Link>
         <span className={styles.count}>{users.length} users</span>
       </header>
       <main className={styles.main}>

--- a/src/app/dashboard/profile/page.tsx
+++ b/src/app/dashboard/profile/page.tsx
@@ -1,7 +1,9 @@
 import { requireVerifiedAuth } from "@/lib/session";
 import { getUserById } from "@/lib/dal/users";
+import { getEmailsForUser } from "@/lib/dal/emailLogs";
 import Link from "next/link";
 import ProfileForm from "@/components/ProfileForm";
+import EmailsReceived from "@/components/EmailsReceived";
 import styles from "./page.module.css";
 
 export default async function ProfilePage({
@@ -16,6 +18,7 @@ export default async function ProfilePage({
   const dbUser = await getUserById(session.user.id);
   const role = dbUser?.role ?? "user";
   const isAdmin = role === "admin";
+  const receivedEmails = await getEmailsForUser(session.user.id);
 
   return (
     <div className={styles.page}>
@@ -37,6 +40,7 @@ export default async function ProfilePage({
           role={role}
           returnTo={returnTo}
         />
+        <EmailsReceived logs={receivedEmails} />
       </main>
     </div>
   );

--- a/src/components/AdminEmailLog.module.css
+++ b/src/components/AdminEmailLog.module.css
@@ -1,0 +1,73 @@
+.tableWrapper {
+  background: var(--color-bg-white);
+  border-radius: 10px;
+  border: 1px solid var(--color-border-medium);
+  overflow: hidden;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.table th {
+  background: var(--color-bg-light);
+  color: var(--color-text-gray);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border-medium);
+  white-space: nowrap;
+}
+
+.table td {
+  padding: 0.85rem 1rem;
+  color: var(--color-text-body);
+  border-bottom: 1px solid var(--color-border-light);
+  vertical-align: top;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table tbody tr:hover {
+  background: var(--color-bg-hover);
+}
+
+.dateCell {
+  white-space: nowrap;
+  color: var(--color-text-gray) !important;
+  font-size: 0.85rem !important;
+}
+
+.recipientName {
+  display: block;
+  font-weight: 500;
+}
+
+.recipientEmail {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--color-text-gray);
+}
+
+.messageCell {
+  max-width: 320px;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  white-space: pre-wrap;
+}
+
+.empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--color-text-gray);
+  font-size: 0.95rem;
+}

--- a/src/components/AdminEmailLog.tsx
+++ b/src/components/AdminEmailLog.tsx
@@ -1,0 +1,48 @@
+import type { EmailLogWithRecipient } from "@/lib/dal/emailLogs";
+import styles from "./AdminEmailLog.module.css";
+
+interface Props {
+  logs: EmailLogWithRecipient[];
+}
+
+export default function AdminEmailLog({ logs }: Props) {
+  if (logs.length === 0) {
+    return <p className={styles.empty}>No emails have been sent yet.</p>;
+  }
+
+  return (
+    <div className={styles.tableWrapper}>
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Date</th>
+            <th>Sender</th>
+            <th>Recipient</th>
+            <th>Subject</th>
+            <th>Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => (
+            <tr key={log.id}>
+              <td className={styles.dateCell}>
+                {new Date(log.sentAt).toLocaleDateString(undefined, {
+                  year: "numeric",
+                  month: "short",
+                  day: "numeric",
+                })}
+              </td>
+              <td>{log.senderName}</td>
+              <td>
+                <span className={styles.recipientName}>{log.recipientName}</span>
+                <span className={styles.recipientEmail}>{log.recipientEmail}</span>
+              </td>
+              <td>{log.subject}</td>
+              <td className={styles.messageCell}>{log.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/AdminUsersList.module.css
+++ b/src/components/AdminUsersList.module.css
@@ -128,6 +128,24 @@
   color: white;
 }
 
+.viewEmailsBtn {
+  padding: 0.35rem 0.8rem;
+  border: 1px solid var(--color-primary-purple);
+  border-radius: 5px;
+  background: transparent;
+  color: var(--color-primary-purple);
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  white-space: nowrap;
+}
+
+.viewEmailsBtn:hover {
+  background: var(--color-primary-purple);
+  color: white;
+}
+
 /* Email Compose Section */
 .emailSection {
   background: var(--color-bg-white);

--- a/src/components/AdminUsersList.tsx
+++ b/src/components/AdminUsersList.tsx
@@ -49,8 +49,8 @@ export default function AdminUsersList({ users, currentUserId }: Props) {
     });
   }
 
-  function handleEmailUser(email: string) {
-    setEmailRecipient(email);
+  function handleEmailUser(userId: string) {
+    setEmailRecipient(userId);
     setEmailResult(null);
     document.getElementById("email-section")?.scrollIntoView({ behavior: "smooth" });
   }
@@ -62,7 +62,7 @@ export default function AdminUsersList({ users, currentUserId }: Props) {
 
     const recipients =
       emailRecipient === "all"
-        ? users.map((u) => u.email)
+        ? users.map((u) => u.id)
         : [emailRecipient];
 
     startTransition(async () => {
@@ -99,7 +99,7 @@ export default function AdminUsersList({ users, currentUserId }: Props) {
             >
               <option value="all">All Users ({users.length})</option>
               {users.map((u) => (
-                <option key={u.id} value={u.email}>
+                <option key={u.id} value={u.id}>
                   {u.name} &lt;{u.email}&gt;
                 </option>
               ))}
@@ -214,10 +214,21 @@ export default function AdminUsersList({ users, currentUserId }: Props) {
                         )}
                         <button
                           type="button"
-                          onClick={() => handleEmailUser(u.email)}
+                          onClick={() => handleEmailUser(u.id)}
                           className={styles.emailBtn}
                         >
                           Email
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            router.push(
+                              `/dashboard/admin/emails?userId=${u.id}`,
+                            )
+                          }
+                          className={styles.viewEmailsBtn}
+                        >
+                          View Emails
                         </button>
                         {canDelete && (
                           <button

--- a/src/components/EmailsReceived.module.css
+++ b/src/components/EmailsReceived.module.css
@@ -1,0 +1,67 @@
+.section {
+  background: var(--color-bg-white);
+  border: 1px solid var(--color-border-medium);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.heading {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  margin-bottom: 1rem;
+}
+
+.empty {
+  color: var(--color-text-gray);
+  font-size: 0.9rem;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid var(--color-border-light);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  background: var(--color-bg-white);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.35rem;
+}
+
+.subject {
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  font-size: 0.95rem;
+}
+
+.date {
+  font-size: 0.8rem;
+  color: var(--color-text-gray);
+  white-space: nowrap;
+}
+
+.sender {
+  font-size: 0.825rem;
+  color: var(--color-text-gray);
+  margin-bottom: 0.5rem;
+}
+
+.message {
+  font-size: 0.9rem;
+  color: var(--color-text-body, #333);
+  white-space: pre-wrap;
+  line-height: 1.55;
+}

--- a/src/components/EmailsReceived.tsx
+++ b/src/components/EmailsReceived.tsx
@@ -1,0 +1,36 @@
+import type { EmailLogWithSender } from "@/lib/dal/emailLogs";
+import styles from "./EmailsReceived.module.css";
+
+interface Props {
+  logs: EmailLogWithSender[];
+}
+
+export default function EmailsReceived({ logs }: Props) {
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.heading}>Emails Received</h2>
+      {logs.length === 0 ? (
+        <p className={styles.empty}>No emails received yet.</p>
+      ) : (
+        <ul className={styles.list}>
+          {logs.map((log) => (
+            <li key={log.id} className={styles.card}>
+              <div className={styles.cardHeader}>
+                <span className={styles.subject}>{log.subject}</span>
+                <span className={styles.date}>
+                  {new Date(log.sentAt).toLocaleDateString(undefined, {
+                    year: "numeric",
+                    month: "short",
+                    day: "numeric",
+                  })}
+                </span>
+              </div>
+              <p className={styles.sender}>From: {log.senderName}</p>
+              <p className={styles.message}>{log.message}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -121,11 +121,38 @@ export const birdEntries = sqliteTable("bird_entries", {
   photoData: text("photo_data"),
 });
 
+export const emailLogs = sqliteTable(
+  "email_logs",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    senderId: text("sender_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    recipientId: text("recipient_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    subject: text("subject").notNull(),
+    message: text("message").notNull(),
+    sentAt: integer("sent_at", { mode: "timestamp_ms" })
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
+      .notNull(),
+  },
+  (table) => [
+    index("email_logs_recipient_idx").on(table.recipientId),
+    index("email_logs_sender_idx").on(table.senderId),
+  ],
+);
+
+export type EmailLog = typeof emailLogs.$inferSelect;
+export type NewEmailLog = typeof emailLogs.$inferInsert;
+
 // Relations
 export const userRelations = relations(user, ({ many }) => ({
   sessions: many(session),
   accounts: many(account),
   birdingEvents: many(birdingEvents),
+  sentEmails: many(emailLogs, { relationName: "sentEmails" }),
+  receivedEmails: many(emailLogs, { relationName: "receivedEmails" }),
 }));
 
 export const sessionRelations = relations(session, ({ one }) => ({
@@ -139,6 +166,19 @@ export const accountRelations = relations(account, ({ one }) => ({
 export const birdingEventRelations = relations(birdingEvents, ({ one, many }) => ({
   user: one(user, { fields: [birdingEvents.userId], references: [user.id] }),
   birds: many(birdEntries),
+}));
+
+export const emailLogRelations = relations(emailLogs, ({ one }) => ({
+  sender: one(user, {
+    fields: [emailLogs.senderId],
+    references: [user.id],
+    relationName: "sentEmails",
+  }),
+  recipient: one(user, {
+    fields: [emailLogs.recipientId],
+    references: [user.id],
+    relationName: "receivedEmails",
+  }),
 }));
 
 // Types

--- a/src/lib/dal/emailLogs.ts
+++ b/src/lib/dal/emailLogs.ts
@@ -1,0 +1,83 @@
+import { eq, desc } from "drizzle-orm";
+import { aliasedTable } from "drizzle-orm";
+import { db } from "@/db";
+import { emailLogs, user as userTable } from "@/db/schema";
+import type { EmailLog } from "@/db/schema";
+
+export type EmailLogWithSender = EmailLog & { senderName: string };
+export type EmailLogWithRecipient = EmailLog & {
+  senderName: string;
+  recipientName: string;
+  recipientEmail: string;
+};
+
+/** Batch-insert one log row per recipient ID. */
+export async function insertEmailLogs(
+  senderId: string,
+  recipientIds: string[],
+  subject: string,
+  message: string,
+): Promise<void> {
+  if (!recipientIds.length) return;
+  await db.insert(emailLogs).values(
+    recipientIds.map((recipientId) => ({
+      senderId,
+      recipientId,
+      subject,
+      message,
+    })),
+  );
+}
+
+/** Emails received by a user, with sender name, newest first. */
+export async function getEmailsForUser(userId: string): Promise<EmailLogWithSender[]> {
+  const senderUser = aliasedTable(userTable, "sender_user");
+
+  const rows = await db
+    .select({
+      id: emailLogs.id,
+      senderId: emailLogs.senderId,
+      recipientId: emailLogs.recipientId,
+      subject: emailLogs.subject,
+      message: emailLogs.message,
+      sentAt: emailLogs.sentAt,
+      senderName: senderUser.name,
+    })
+    .from(emailLogs)
+    .innerJoin(senderUser, eq(emailLogs.senderId, senderUser.id))
+    .where(eq(emailLogs.recipientId, userId))
+    .orderBy(desc(emailLogs.sentAt));
+
+  return rows;
+}
+
+/** All email logs (admin view), optionally filtered by recipientId. */
+export async function getAllEmailLogs(
+  recipientId?: string,
+): Promise<EmailLogWithRecipient[]> {
+  const senderUser = aliasedTable(userTable, "sender_user");
+  const recipientUser = aliasedTable(userTable, "recipient_user");
+
+  const query = db
+    .select({
+      id: emailLogs.id,
+      senderId: emailLogs.senderId,
+      recipientId: emailLogs.recipientId,
+      subject: emailLogs.subject,
+      message: emailLogs.message,
+      sentAt: emailLogs.sentAt,
+      senderName: senderUser.name,
+      recipientName: recipientUser.name,
+      recipientEmail: recipientUser.email,
+    })
+    .from(emailLogs)
+    .innerJoin(senderUser, eq(emailLogs.senderId, senderUser.id))
+    .innerJoin(recipientUser, eq(emailLogs.recipientId, recipientUser.id))
+    .orderBy(desc(emailLogs.sentAt));
+
+  if (recipientId) {
+    return query.where(eq(emailLogs.recipientId, recipientId));
+  }
+
+  return query;
+}


### PR DESCRIPTION
- Add email_logs table to schema with senderId/recipientId FKs (cascade on delete)
- Migration 0005_add_email_logs.sql with indexes on sender and recipient
- DAL (emailLogs.ts): insertEmailLogs, getEmailsForUser, getAllEmailLogs with aliased double-joins
- sendEmailAction now accepts recipientIds (user IDs), resolves emails, sends via Resend, then logs
- AdminUsersList: recipient select uses user IDs; new "View Emails" button navigates to audit page
- EmailsReceived server component on profile page showing received email cards
- AdminEmailLog server component with table view (Date/Sender/Recipient/Subject/Message)
- /dashboard/admin/emails audit page with optional ?userId= filter banner
- "Email Audit Log →" link added to admin users page header