### PR TITLE
feat: centralize bird payload construction into shared toBirdInsert t…

### DIFF
--- a/src/app/api/events/[id]/birds/route.ts
+++ b/src/app/api/events/[id]/birds/route.ts
@@ -3,6 +3,7 @@ import { eq, and } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { birdingEvents, birdEntries } from "@/db/schema";
+import { toBirdInsert, BirdFormInput } from "@/lib/birds";
 
 export async function POST(
   req: NextRequest,
@@ -23,22 +24,11 @@ export async function POST(
 
   if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const { type, species, locationName, lat, lng, dateStamp, notes, photoPath, photoData } = await req.json();
+  const body: BirdFormInput = await req.json();
 
   const [bird] = await db
     .insert(birdEntries)
-    .values({
-      eventId,
-      type,
-      species,
-      locationName,
-      lat: lat ?? null,
-      lng: lng ?? null,
-      dateStamp,
-      notes: notes ?? null,
-      photoPath: photoData ? null : (photoPath ?? null),
-      photoData: photoData ?? null,
-    })
+    .values(toBirdInsert(body, eventId))
     .returning();
 
   return NextResponse.json({ ok: true, birdId: bird.id });

--- a/src/app/api/events/[id]/birds/route.ts
+++ b/src/app/api/events/[id]/birds/route.ts
@@ -1,9 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq, and } from "drizzle-orm";
 import { auth } from "@/lib/auth";
-import { db } from "@/db";
-import { birdingEvents, birdEntries } from "@/db/schema";
-import { toBirdInsert, BirdFormInput } from "@/lib/birds";
+import { addBirdToEvent } from "@/lib/dal/events";
+import type { BirdFormInput } from "@/lib/birds";
 
 export async function POST(
   req: NextRequest,
@@ -17,19 +15,10 @@ export async function POST(
   const eventId = parseInt(id, 10);
   if (isNaN(eventId)) return NextResponse.json({ error: "Invalid id" }, { status: 400 });
 
-  const [event] = await db
-    .select()
-    .from(birdingEvents)
-    .where(and(eq(birdingEvents.id, eventId), eq(birdingEvents.userId, session.user.id)));
-
-  if (!event) return NextResponse.json({ error: "Not found" }, { status: 404 });
-
   const body: BirdFormInput = await req.json();
 
-  const [bird] = await db
-    .insert(birdEntries)
-    .values(toBirdInsert(body, eventId))
-    .returning();
+  const bird = await addBirdToEvent(eventId, session.user.id, body);
+  if (!bird) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   return NextResponse.json({ ok: true, birdId: bird.id });
 }

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -4,18 +4,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { birdingEvents, birdEntries } from "@/db/schema";
 import { deleteUploadedFile } from "@/lib/uploads";
-
-type BirdPayload = {
-  type: string;
-  species: string;
-  locationName: string;
-  lat?: number | null;
-  lng?: number | null;
-  dateStamp: string;
-  notes?: string | null;
-  photoPath?: string | null;
-  photoData?: string | null;
-};
+import { toBirdInsert, BirdFormInput } from "@/lib/birds";
 
 export async function PUT(
   req: NextRequest,
@@ -53,18 +42,7 @@ export async function PUT(
 
     if (birds && birds.length > 0) {
       await tx.insert(birdEntries).values(
-        birds.map((b: BirdPayload) => ({
-          eventId,
-          type: b.type,
-          species: b.species,
-          locationName: b.locationName,
-          lat: b.lat ?? null,
-          lng: b.lng ?? null,
-          dateStamp: b.dateStamp,
-          notes: b.notes ?? null,
-          photoPath: b.photoData ? null : (b.photoPath ?? null),
-          photoData: b.photoData ?? null,
-        })),
+        birds.map((b: BirdFormInput) => toBirdInsert(b, eventId)),
       );
     }
   });

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "../../../lib/auth";
 import { db } from "../../../db";
 import { birdingEvents, birdEntries } from "../../../db/schema";
+import { toBirdInsert, BirdFormInput } from "@/lib/birds";
 
 export async function POST(req: NextRequest) {
   const session = await auth.api.getSession({ headers: req.headers });
@@ -20,30 +21,7 @@ export async function POST(req: NextRequest) {
 
   if (birds && birds.length > 0) {
     await db.insert(birdEntries).values(
-      birds.map(
-        (b: {
-          type: string;
-          species: string;
-          locationName: string;
-          lat?: number;
-          lng?: number;
-          dateStamp: string;
-          notes?: string;
-          photoPath?: string;
-          photoData?: string;
-        }) => ({
-          eventId: event.id,
-          type: b.type,
-          species: b.species,
-          locationName: b.locationName,
-          lat: b.lat ?? null,
-          lng: b.lng ?? null,
-          dateStamp: b.dateStamp,
-          notes: b.notes ?? null,
-          photoPath: b.photoData ? null : (b.photoPath ?? null),
-          photoData: b.photoData ?? null,
-        }),
-      ),
+      birds.map((b: BirdFormInput) => toBirdInsert(b, event.id)),
     );
   }
 

--- a/src/lib/birds.ts
+++ b/src/lib/birds.ts
@@ -1,0 +1,34 @@
+import type { NewBirdEntry } from "@/db/schema";
+
+export type BirdFormInput = {
+  type: string;
+  species: string;
+  locationName: string;
+  lat?: number | null;
+  lng?: number | null;
+  dateStamp: string;
+  notes?: string | null;
+  photoPath?: string | null;
+  photoData?: string | null;
+};
+
+/**
+ * Transforms bird form input into a DB insert payload.
+ *
+ * Photo mutex rule: when photoData is present, photoPath is set to null
+ * so the DB never stores both representations simultaneously.
+ */
+export function toBirdInsert(b: BirdFormInput, eventId: number): NewBirdEntry {
+  return {
+    eventId,
+    type: b.type,
+    species: b.species,
+    locationName: b.locationName,
+    lat: b.lat ?? null,
+    lng: b.lng ?? null,
+    dateStamp: b.dateStamp,
+    notes: b.notes ?? null,
+    photoPath: b.photoData ? null : (b.photoPath ?? null),
+    photoData: b.photoData ?? null,
+  };
+}

--- a/src/lib/dal/events.ts
+++ b/src/lib/dal/events.ts
@@ -2,6 +2,7 @@ import { eq, and } from "drizzle-orm";
 import { db } from "@/db";
 import { birdingEvents, birdEntries } from "@/db/schema";
 import type { BirdingEvent, BirdEntry } from "@/db/schema";
+import { toBirdInsert, BirdFormInput } from "@/lib/birds";
 
 export type EventWithBirds = BirdingEvent & { birds: BirdEntry[] };
 
@@ -39,6 +40,30 @@ export async function getBirdEntry(
     .where(and(eq(birdEntries.id, birdId), eq(birdingEvents.userId, userId)));
 
   return row?.bird ?? null;
+}
+
+/**
+ * Insert a bird entry for a given event, enforcing user ownership.
+ * Returns the inserted bird, or null if the event does not exist or is not owned by the user.
+ */
+export async function addBirdToEvent(
+  eventId: number,
+  userId: string,
+  bird: BirdFormInput,
+): Promise<BirdEntry | null> {
+  const [event] = await db
+    .select()
+    .from(birdingEvents)
+    .where(and(eq(birdingEvents.id, eventId), eq(birdingEvents.userId, userId)));
+
+  if (!event) return null;
+
+  const [inserted] = await db
+    .insert(birdEntries)
+    .values(toBirdInsert(bird, eventId))
+    .returning();
+
+  return inserted ?? null;
 }
 
 /** Fetch a single event with its birds, enforcing user ownership. Returns null if not found or not owned. */

--- a/src/tests/unit/birds.test.ts
+++ b/src/tests/unit/birds.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { toBirdInsert, BirdFormInput } from "@/lib/birds";
+
+describe("toBirdInsert", () => {
+  const baseInput: BirdFormInput = {
+    type: "Songbird",
+    species: "American Robin",
+    locationName: "Central Park",
+    dateStamp: "2026-04-11",
+  };
+
+  it("maps required fields and sets optional fields to null when absent", () => {
+    const result = toBirdInsert(baseInput, 42);
+    expect(result).toEqual({
+      eventId: 42,
+      type: "Songbird",
+      species: "American Robin",
+      locationName: "Central Park",
+      dateStamp: "2026-04-11",
+      lat: null,
+      lng: null,
+      notes: null,
+      photoPath: null,
+      photoData: null,
+    });
+  });
+
+  it("includes lat and lng when provided", () => {
+    const input: BirdFormInput = { ...baseInput, lat: 40.785, lng: -73.968 };
+    const result = toBirdInsert(input, 1);
+    expect(result.lat).toBe(40.785);
+    expect(result.lng).toBe(-73.968);
+  });
+
+  it("includes notes when provided", () => {
+    const input: BirdFormInput = { ...baseInput, notes: "Singing loudly" };
+    const result = toBirdInsert(input, 1);
+    expect(result.notes).toBe("Singing loudly");
+  });
+
+  it("photo mutex rule: sets photoPath to null when photoData is present", () => {
+    const input: BirdFormInput = {
+      ...baseInput,
+      photoData: "data:image/png;base64,abc123",
+      photoPath: "/uploads/photo.png",
+    };
+    const result = toBirdInsert(input, 1);
+    expect(result.photoData).toBe("data:image/png;base64,abc123");
+    expect(result.photoPath).toBeNull();
+  });
+
+  it("photo mutex rule: uses photoPath when photoData is absent", () => {
+    const input: BirdFormInput = {
+      ...baseInput,
+      photoPath: "/uploads/photo.png",
+    };
+    const result = toBirdInsert(input, 1);
+    expect(result.photoPath).toBe("/uploads/photo.png");
+    expect(result.photoData).toBeNull();
+  });
+
+  it("photo mutex rule: both null when neither is provided", () => {
+    const result = toBirdInsert(baseInput, 1);
+    expect(result.photoPath).toBeNull();
+    expect(result.photoData).toBeNull();
+  });
+
+  it("photo mutex rule: photoPath used when photoData is empty string (falsy), photoData preserved as empty string", () => {
+    const input: BirdFormInput = {
+      ...baseInput,
+      photoData: "",
+      photoPath: "/uploads/photo.png",
+    };
+    const result = toBirdInsert(input, 1);
+    // empty string is falsy → photoData does NOT override photoPath
+    // ?? null coercion preserves "" as "" (only nullish values become null)
+    expect(result.photoPath).toBe("/uploads/photo.png");
+    expect(result.photoData).toBe("");
+  });
+
+  it("sets eventId correctly", () => {
+    expect(toBirdInsert(baseInput, 99).eventId).toBe(99);
+    expect(toBirdInsert(baseInput, 1).eventId).toBe(1);
+  });
+
+  it("coerces explicit null optional fields to null", () => {
+    const input: BirdFormInput = {
+      ...baseInput,
+      lat: null,
+      lng: null,
+      notes: null,
+      photoPath: null,
+      photoData: null,
+    };
+    const result = toBirdInsert(input, 5);
+    expect(result.lat).toBeNull();
+    expect(result.lng).toBeNull();
+    expect(result.notes).toBeNull();
+    expect(result.photoPath).toBeNull();
+    expect(result.photoData).toBeNull();
+  });
+});


### PR DESCRIPTION
…ransformer

Introduces `src/lib/birds.ts` with a shared `BirdFormInput` type and `toBirdInsert(b, eventId)` pure function that owns the photo mutex rule and all ?? null coercions. Removes the duplicated inline transform and the local `BirdPayload` type from three API routes.

9 new unit tests cover the photo mutex rule, null coercions, and all field-mapping paths — no DB or mocks needed.

Closes #61