### PR TITLE
feat: add failure discrimination to parseIdentification()

### DIFF
--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -58,14 +58,17 @@ export async function POST(req: NextRequest) {
   }
 
   const result = parseIdentification(responseText);
-  if (!result.ok) {
-    const status = result.reason === "parse_error" ? 422 : 200;
-    const error =
-      result.reason === "parse_error"
-        ? "Could not parse bird identification from AI response"
-        : "AI could not identify a bird in this photo";
-    return NextResponse.json({ error }, { status });
+  if (result.ok) {
+    return NextResponse.json(result.value);
   }
 
-  return NextResponse.json(result.value);
+  // strict:false disables strictNullChecks, which prevents TS from narrowing
+  // the discriminated union via control-flow alone — cast explicitly.
+  const { reason } = result as { ok: false; reason: "not_identified" | "parse_error" };
+  const status = reason === "parse_error" ? 422 : 200;
+  const error =
+    reason === "parse_error"
+      ? "Could not parse bird identification from AI response"
+      : "AI could not identify a bird in this photo";
+  return NextResponse.json({ error }, { status });
 }

--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -58,9 +58,14 @@ export async function POST(req: NextRequest) {
   }
 
   const result = parseIdentification(responseText);
-  if (!result) {
-    return NextResponse.json({ error: "Could not identify bird from photo" }, { status: 422 });
+  if (!result.ok) {
+    const status = result.reason === "parse_error" ? 422 : 200;
+    const error =
+      result.reason === "parse_error"
+        ? "Could not parse bird identification from AI response"
+        : "AI could not identify a bird in this photo";
+    return NextResponse.json({ error }, { status });
   }
 
-  return NextResponse.json(result);
+  return NextResponse.json(result.value);
 }

--- a/src/components/BirdChatWidget.tsx
+++ b/src/components/BirdChatWidget.tsx
@@ -65,9 +65,9 @@ export default function BirdChatWidget({ onIdentified }: Props) {
       }
 
       const result = parseIdentification(accumulated);
-      if (result && !identified) {
+      if (result.ok && !identified) {
         setIdentified(true);
-        onIdentified(result);
+        onIdentified(result.value);
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Something went wrong. Please try again.";

--- a/src/lib/chat.ts
+++ b/src/lib/chat.ts
@@ -1,27 +1,45 @@
+/** Documents the JSON shape the AI is required to produce. Single source of truth. */
+export interface BirdIdentificationPayload {
+  identified: true;
+  type: string;
+  species: string;
+}
+
 export interface BirdIdentification {
   type: string;
   species: string;
   summary: string;
 }
 
+export type ParseResult =
+  | { ok: true; value: BirdIdentification }
+  | { ok: false; reason: "not_identified" } // AI deliberately said no bird — valid response
+  | { ok: false; reason: "parse_error" }; // malformed / no JSON found — unexpected
+
 /** Parses the JSON identification block the AI embeds in its final response. */
-export function parseIdentification(text: string): BirdIdentification | null {
+export function parseIdentification(text: string): ParseResult {
   // Strip markdown code fences so we can find bare JSON objects
   const stripped = text.replace(/```(?:json)?\s*([\s\S]*?)```/g, "$1");
 
   // Find every { ... } candidate and try each
   const candidates = stripped.matchAll(/\{[\s\S]*?\}/g);
+  let foundNotIdentified = false;
+
   for (const match of candidates) {
     try {
       const data = JSON.parse(match[0]);
-      if (data.identified && data.type && data.species) {
+      if (data.identified === true && data.type && data.species) {
         const jsonIndex = text.indexOf(match[0].trim().slice(0, 20));
         const summary = text.slice(0, jsonIndex >= 0 ? jsonIndex : 0).replace(/```(?:json)?/g, "").trim();
-        return { type: data.type, species: data.species, summary };
+        return { ok: true, value: { type: data.type, species: data.species, summary } };
+      }
+      if (data.identified === false) {
+        foundNotIdentified = true;
       }
     } catch {
       // not valid JSON, try next
     }
   }
-  return null;
+
+  return { ok: false, reason: foundNotIdentified ? "not_identified" : "parse_error" };
 }

--- a/src/tests/unit/chat.test.ts
+++ b/src/tests/unit/chat.test.ts
@@ -2,56 +2,75 @@ import { describe, it, expect } from "vitest";
 import { parseIdentification } from "@/lib/chat";
 
 describe("parseIdentification", () => {
-  it("returns null when no JSON block present", () => {
-    expect(parseIdentification("That looks like a sparrow!")).toBeNull();
+  it("returns parse_error when no JSON block present", () => {
+    const result = parseIdentification("That looks like a sparrow!");
+    expect(result).toEqual({ ok: false, reason: "parse_error" });
   });
 
   it("parses a valid identification block", () => {
     const text = `Based on your description, I can identify this bird.
 {"identified": true, "type": "Songbird", "species": "American Robin"}
 It has a red breast and dark back.`;
-    expect(parseIdentification(text)).toEqual({
-      type: "Songbird",
-      species: "American Robin",
-      summary: "Based on your description, I can identify this bird.",
+    const result = parseIdentification(text);
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        type: "Songbird",
+        species: "American Robin",
+        summary: "Based on your description, I can identify this bird.",
+      },
     });
   });
 
   it("includes empty summary when JSON block is at start", () => {
     const text = `{"identified": true, "type": "Raptor", "species": "Osprey"}`;
-    expect(parseIdentification(text)).toEqual({
-      type: "Raptor",
-      species: "Osprey",
-      summary: "",
+    const result = parseIdentification(text);
+    expect(result).toEqual({
+      ok: true,
+      value: { type: "Raptor", species: "Osprey", summary: "" },
     });
   });
 
-  it("returns null when identified is false", () => {
+  it("returns not_identified when identified is false", () => {
     const text = `{"identified": false, "type": "Unknown", "species": "Unknown"}`;
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "not_identified" });
   });
 
-  it("returns null for malformed JSON", () => {
+  it("returns parse_error for malformed JSON", () => {
     const text = `{"identified": true, "type": "Raptor" broken`;
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "parse_error" });
   });
 
-  it("returns null when type is missing", () => {
+  it("returns parse_error when type is missing", () => {
     const text = `{"identified": true, "species": "Osprey"}`;
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "parse_error" });
   });
 
-  it("returns null when species is missing", () => {
+  it("returns parse_error when species is missing", () => {
     const text = `{"identified": true, "type": "Raptor"}`;
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "parse_error" });
   });
 
   it("parses multiline JSON inside a markdown code fence", () => {
     const text = `Here is my identification.\n\n\`\`\`json\n{\n  "identified": true,\n  "type": "Songbird",\n  "species": "Red-breasted Nuthatch"\n}\n\`\`\``;
-    expect(parseIdentification(text)).toEqual({
-      type: "Songbird",
-      species: "Red-breasted Nuthatch",
-      summary: "Here is my identification.",
+    const result = parseIdentification(text);
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        type: "Songbird",
+        species: "Red-breasted Nuthatch",
+        summary: "Here is my identification.",
+      },
     });
+  });
+
+  it("returns not_identified when AI responds with identified false and no type/species", () => {
+    const text = `I need more information. {"identified": false}`;
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "not_identified" });
   });
 });

--- a/src/tests/unit/photoIdentify.test.ts
+++ b/src/tests/unit/photoIdentify.test.ts
@@ -7,10 +7,12 @@ describe("parseIdentification - photo AI response shapes", () => {
       "The Robin is a small passerine bird with an orange-red breast. " +
       'It is common in gardens and woodland edges.\n{"identified": true, "type": "Songbird", "species": "European Robin"}';
     const result = parseIdentification(text);
-    expect(result).not.toBeNull();
-    expect(result?.type).toBe("Songbird");
-    expect(result?.species).toBe("European Robin");
-    expect(result?.summary).toContain("Robin");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.type).toBe("Songbird");
+      expect(result.value.species).toBe("European Robin");
+      expect(result.value.summary).toContain("Robin");
+    }
   });
 
   it("parses JSON wrapped in markdown fences", () => {
@@ -18,31 +20,39 @@ describe("parseIdentification - photo AI response shapes", () => {
       "A large bird of prey commonly seen soaring over open countryside.\n" +
       '```json\n{"identified": true, "type": "Raptor", "species": "Red Kite"}\n```';
     const result = parseIdentification(text);
-    expect(result).not.toBeNull();
-    expect(result?.type).toBe("Raptor");
-    expect(result?.species).toBe("Red Kite");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.type).toBe("Raptor");
+      expect(result.value.species).toBe("Red Kite");
+    }
   });
 
-  it("returns null when identified is false", () => {
+  it("returns not_identified when identified is false", () => {
     const text = 'I need more information. {"identified": false}';
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "not_identified" });
   });
 
-  it("returns null when JSON block is missing", () => {
+  it("returns parse_error when JSON block is missing", () => {
     const text = "This looks like a sparrow but I cannot be certain.";
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "parse_error" });
   });
 
-  it("returns null when type or species is missing from JSON", () => {
+  it("returns parse_error when type or species is missing from JSON", () => {
     const text = 'A bird.\n{"identified": true, "type": "Songbird"}';
-    expect(parseIdentification(text)).toBeNull();
+    const result = parseIdentification(text);
+    expect(result).toEqual({ ok: false, reason: "parse_error" });
   });
 
   it("extracts summary as text before the JSON block", () => {
     const summary = "The Barn Owl is a nocturnal hunter with a heart-shaped face.";
     const text = `${summary}\n{"identified": true, "type": "Owl", "species": "Barn Owl"}`;
     const result = parseIdentification(text);
-    expect(result?.summary).toContain("Barn Owl");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.summary).toContain("Barn Owl");
+    }
   });
 
   it("handles multiple JSON-like objects and picks the correct one", () => {
@@ -50,6 +60,9 @@ describe("parseIdentification - photo AI response shapes", () => {
       'The user mentioned {"color": "brown"}. Based on this: the bird is a Thrush.\n' +
       '{"identified": true, "type": "Songbird", "species": "Song Thrush"}';
     const result = parseIdentification(text);
-    expect(result?.species).toBe("Song Thrush");
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.species).toBe("Song Thrush");
+    }
   });
 });


### PR DESCRIPTION
Implements RFC in issue #63: replaces `BirdIdentification | null` with a `ParseResult` discriminated union that distinguishes "AI said no bird" from "malformed response".

- Adds `BirdIdentificationPayload` interface as the documented JSON contract co-located with the parser
- `POST /api/identify-photo` now returns 200 for `not_identified` and 422 for `parse_error`
- All 137 unit tests pass

Closes #63

Generated with [Claude Code](https://claude.ai/code)