### PR TITLE
feat(BRD-79): implement freemium billing model with plan-gated features

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,10 @@ DATABASE_URL=
 
 # OpenRouter API key for AI bird identification
 OPENROUTER_API_KEY=
-# Override the default model (openai/gpt-oss-120b)
+# Model for paid users and admins (defaults to openrouter/openai/gpt-oss-120b)
 OPENROUTER_MODEL=
+# Model for free tier users (defaults to openrouter/auto)
+OPENROUTER_FREE_MODEL=
 
 # Resend email service — resend.com/api-keys
 RESEND_API_KEY=

--- a/drizzle/0007_add_billing_plan.sql
+++ b/drizzle/0007_add_billing_plan.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD COLUMN `billing_plan` text NOT NULL DEFAULT 'free';

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import OpenAI from "openai";
 import { NextRequest } from "next/server";
 import { auth } from "../../../lib/auth";
 import { getAuthBaseUrl } from "../../../lib/get-auth-base-url";
+import { getUserBillingInfo, selectChatModel } from "../../../lib/billing";
 
 const SYSTEM_PROMPT = `You are an expert ornithologist helping birding enthusiasts identify birds.
 
@@ -15,8 +16,6 @@ When a user describes a bird they have seen, identify it and respond with:
      {"identified": true, "type": "...", "species": "..."}
 
 If you are still gathering information, do NOT include the JSON block yet.`;
-
-const DEFAULT_MODEL = "openrouter/free";
 
 function getClient() {
   return new OpenAI({
@@ -39,7 +38,11 @@ export async function POST(req: NextRequest) {
     messages: { role: "user" | "assistant"; content: string }[];
   };
 
-  const model = process.env.OPENROUTER_MODEL ?? DEFAULT_MODEL;
+  const billingInfo = await getUserBillingInfo(session.user.id);
+  const model = selectChatModel(
+    billingInfo?.role ?? "user",
+    billingInfo?.billingPlan ?? "free",
+  );
   const client = getClient();
 
   // Create the stream first — allows errors (auth, quota, bad model) to surface as HTTP errors

--- a/src/app/api/identify-photo/route.ts
+++ b/src/app/api/identify-photo/route.ts
@@ -3,6 +3,7 @@ import OpenAI from "openai";
 import { auth } from "@/lib/auth";
 import { parseIdentification } from "@/lib/chat";
 import { getAuthBaseUrl } from "@/lib/get-auth-base-url";
+import { getUserBillingInfo, canAccessPaidFeatures } from "@/lib/billing";
 
 const VISION_MODEL = process.env.OPENROUTER_VISION_MODEL ?? "openai/gpt-4o";
 
@@ -29,6 +30,20 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   if (!session.user.emailVerified)
     return NextResponse.json({ error: "Email not verified" }, { status: 403 });
+
+  const billingInfo = await getUserBillingInfo(session.user.id);
+  if (
+    !billingInfo ||
+    !canAccessPaidFeatures(billingInfo.role, billingInfo.billingPlan)
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          "Photo identification is a paid feature. Please upgrade your plan to use it.",
+      },
+      { status: 403 },
+    );
+  }
 
   const body = (await req.json()) as { photoBase64?: string };
   const { photoBase64 } = body;

--- a/src/app/billing/actions.ts
+++ b/src/app/billing/actions.ts
@@ -1,0 +1,24 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { eq } from "drizzle-orm";
+import { requireVerifiedAuth } from "@/lib/session";
+import { db } from "@/db";
+import { user as userTable } from "@/db/schema";
+import type { BillingPlan } from "@/lib/billing";
+
+/**
+ * Updates the current user's billing plan.
+ * Requires authenticated, verified user.
+ * Redirects to /dashboard on success.
+ */
+export async function updateBillingPlan(plan: BillingPlan): Promise<void> {
+  const session = await requireVerifiedAuth();
+
+  await db
+    .update(userTable)
+    .set({ billingPlan: plan })
+    .where(eq(userTable.id, session.user.id));
+
+  redirect("/dashboard");
+}

--- a/src/app/billing/actions.ts
+++ b/src/app/billing/actions.ts
@@ -1,10 +1,8 @@
 "use server";
 
 import { redirect } from "next/navigation";
-import { eq } from "drizzle-orm";
 import { requireVerifiedAuth } from "@/lib/session";
-import { db } from "@/db";
-import { user as userTable } from "@/db/schema";
+import { updateUserBillingPlan } from "@/lib/dal/users";
 import type { BillingPlan } from "@/lib/billing";
 
 /**
@@ -15,10 +13,7 @@ import type { BillingPlan } from "@/lib/billing";
 export async function updateBillingPlan(plan: BillingPlan): Promise<void> {
   const session = await requireVerifiedAuth();
 
-  await db
-    .update(userTable)
-    .set({ billingPlan: plan })
-    .where(eq(userTable.id, session.user.id));
+  await updateUserBillingPlan(session.user.id, plan);
 
   redirect("/dashboard");
 }

--- a/src/app/billing/page.module.css
+++ b/src/app/billing/page.module.css
@@ -1,0 +1,216 @@
+.page {
+  min-height: 100vh;
+  background: var(--color-bg-light);
+}
+
+.header {
+  background: var(--color-bg-white);
+  border-bottom: 1px solid var(--color-border-medium);
+  padding: 1rem 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.back {
+  color: var(--color-primary-blue);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.back:hover {
+  text-decoration: underline;
+}
+
+.headerTitle {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-primary-navy);
+  flex: 1;
+}
+
+.main {
+  max-width: 860px;
+  margin: 2.5rem auto;
+  padding: 0 1.5rem;
+}
+
+.intro {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.pageTitle {
+  font-size: 2rem;
+  color: var(--color-primary-navy);
+  margin-bottom: 0.5rem;
+}
+
+.subtitle {
+  color: var(--color-text-gray);
+  font-size: 1rem;
+}
+
+.currentPlan {
+  display: inline-block;
+  background: var(--color-bg-yellow-light);
+  color: var(--color-primary-navy);
+  border: 1px solid var(--color-primary-yellow);
+  border-radius: 20px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-top: 0.75rem;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 640px) {
+  .cards {
+    grid-template-columns: 1fr;
+  }
+}
+
+.card {
+  background: var(--color-bg-white);
+  border: 2px solid var(--color-border-light);
+  border-radius: 12px;
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cardActive {
+  border-color: var(--color-primary-blue);
+  background: var(--color-bg-blue-light);
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.planBadge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.planBadgeFree {
+  background: var(--color-bg-light);
+  color: var(--color-text-gray);
+  border: 1px solid var(--color-border-light);
+}
+
+.planBadgePaid {
+  background: var(--color-primary-yellow);
+  color: var(--color-primary-navy);
+}
+
+.planName {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-primary-navy);
+}
+
+.planPrice {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--color-primary-blue);
+  margin: 0;
+}
+
+.planPrice span {
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: var(--color-text-gray);
+}
+
+.featureList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  flex: 1;
+}
+
+.featureItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--color-text-medium);
+}
+
+.featureCheck {
+  color: var(--color-success);
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.featureX {
+  color: var(--color-error);
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 1px;
+}
+
+.selectBtn {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.selectBtnFree {
+  background: var(--color-bg-light);
+  color: var(--color-text-medium);
+  border: 1px solid var(--color-border-cancel);
+}
+
+.selectBtnFree:hover:not(:disabled) {
+  background: var(--color-bg-hover);
+}
+
+.selectBtnPaid {
+  background: var(--color-primary-purple);
+  color: white;
+}
+
+.selectBtnPaid:hover:not(:disabled) {
+  background: var(--color-purple-hover);
+}
+
+.activeBadge {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: var(--color-primary-blue);
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: center;
+}
+
+.note {
+  margin-top: 2rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,0 +1,140 @@
+import { requireVerifiedAuth } from "@/lib/session";
+import { getUserBillingInfo } from "@/lib/billing";
+import { updateBillingPlan } from "./actions";
+import Link from "next/link";
+import styles from "./page.module.css";
+
+export default async function BillingPage() {
+  const session = await requireVerifiedAuth();
+  const info = await getUserBillingInfo(session.user.id);
+  const currentPlan = info?.billingPlan ?? "free";
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <Link href="/dashboard" className={styles.back}>
+          ← Back to Dashboard
+        </Link>
+        <h1 className={styles.headerTitle}>Choose Your Plan</h1>
+      </header>
+
+      <main className={styles.main}>
+        <div className={styles.intro}>
+          <h2 className={styles.pageTitle}>Upgrade Bird Cage</h2>
+          <p className={styles.subtitle}>
+            Start free and upgrade when you&apos;re ready for more powerful AI features.
+          </p>
+          <span className={styles.currentPlan}>
+            Current plan: {currentPlan === "paid" ? "Paid" : "Free"}
+          </span>
+        </div>
+
+        <div className={styles.cards}>
+          {/* Free Plan Card */}
+          <div className={currentPlan === "free" ? `${styles.card} ${styles.cardActive}` : styles.card}>
+            <div className={styles.cardHeader}>
+              <span className={`${styles.planBadge} ${styles.planBadgeFree}`}>Free</span>
+              <span className={styles.planName}>Starter</span>
+            </div>
+
+            <p className={styles.planPrice}>
+              $0 <span>/ month</span>
+            </p>
+
+            <ul className={styles.featureList}>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Unlimited birding events
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Unlimited bird sightings
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                AI chat bird identification (free model)
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Location tracking & map view
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureX}>✗</span>
+                Photo-based AI identification
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureX}>✗</span>
+                Advanced AI model (GPT-4o quality)
+              </li>
+            </ul>
+
+            {currentPlan === "free" ? (
+              <div className={styles.activeBadge}>Current Plan</div>
+            ) : (
+              <form
+                action={async () => {
+                  "use server";
+                  await updateBillingPlan("free");
+                }}
+              >
+                <button type="submit" className={`${styles.selectBtn} ${styles.selectBtnFree}`}>
+                  Switch to Free
+                </button>
+              </form>
+            )}
+          </div>
+
+          {/* Paid Plan Card */}
+          <div className={currentPlan === "paid" ? `${styles.card} ${styles.cardActive}` : styles.card}>
+            <div className={styles.cardHeader}>
+              <span className={`${styles.planBadge} ${styles.planBadgePaid}`}>Pro</span>
+              <span className={styles.planName}>Birder Pro</span>
+            </div>
+
+            <p className={styles.planPrice}>
+              $9 <span>/ month</span>
+            </p>
+
+            <ul className={styles.featureList}>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Everything in Free
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Photo-based AI bird identification
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Advanced AI model for chat identification
+              </li>
+              <li className={styles.featureItem}>
+                <span className={styles.featureCheck}>✓</span>
+                Priority AI response speed
+              </li>
+            </ul>
+
+            {currentPlan === "paid" ? (
+              <div className={styles.activeBadge}>Current Plan</div>
+            ) : (
+              <form
+                action={async () => {
+                  "use server";
+                  await updateBillingPlan("paid");
+                }}
+              >
+                <button type="submit" className={`${styles.selectBtn} ${styles.selectBtnPaid}`}>
+                  Upgrade to Pro
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+
+        <p className={styles.note}>
+          No payment required — billing plan is a feature flag for this demo.
+        </p>
+      </main>
+    </div>
+  );
+}

--- a/src/app/birds/[id]/edit/page.tsx
+++ b/src/app/birds/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { requireVerifiedAuth } from "@/lib/session";
 import { getBirdEntry } from "@/lib/dal/events";
 import { getUserById } from "@/lib/dal/users";
+import { canAccessPaidFeatures } from "@/lib/billing";
 import BirdEditForm from "@/components/BirdEditForm";
 import NavDropdown from "@/components/NavDropdown";
 import Link from "next/link";
@@ -29,6 +30,10 @@ export default async function BirdEditPage({
 
   const backHref = from ?? "/dashboard";
   const isAdmin = dbUser?.role === "admin";
+  const isPaidUser = canAccessPaidFeatures(
+    dbUser?.role ?? "user",
+    (dbUser?.billingPlan as "free" | "paid") ?? "free",
+  );
 
   return (
     <div className={styles.page}>
@@ -42,7 +47,7 @@ export default async function BirdEditPage({
         </div>
       </header>
       <main className={styles.main}>
-        <BirdEditForm bird={bird} returnTo={backHref} />
+        <BirdEditForm bird={bird} returnTo={backHref} isPaidUser={isPaidUser} />
       </main>
     </div>
   );

--- a/src/app/events/[id]/add-bird/page.tsx
+++ b/src/app/events/[id]/add-bird/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { requireVerifiedAuth } from "@/lib/session";
 import { getEventWithBirds } from "@/lib/dal/events";
 import { getUserById } from "@/lib/dal/users";
+import { canAccessPaidFeatures } from "@/lib/billing";
 import AddBirdForm from "@/components/AddBirdForm";
 import NavDropdown from "@/components/NavDropdown";
 import Link from "next/link";
@@ -25,6 +26,10 @@ export default async function AddBirdPage({
   if (!data) notFound();
 
   const isAdmin = dbUser?.role === "admin";
+  const isPaidUser = canAccessPaidFeatures(
+    dbUser?.role ?? "user",
+    (dbUser?.billingPlan as "free" | "paid") ?? "free",
+  );
 
   return (
     <div className={styles.page}>
@@ -38,7 +43,7 @@ export default async function AddBirdPage({
         </div>
       </header>
       <main className={styles.main}>
-        <AddBirdForm eventId={eventId} />
+        <AddBirdForm eventId={eventId} isPaidUser={isPaidUser} />
       </main>
     </div>
   );

--- a/src/app/events/[id]/edit/page.tsx
+++ b/src/app/events/[id]/edit/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { requireVerifiedAuth } from "@/lib/session";
 import { getEventWithBirds } from "@/lib/dal/events";
 import { getUserById } from "@/lib/dal/users";
+import { canAccessPaidFeatures } from "@/lib/billing";
 import EventForm from "@/components/EventForm";
 import NavDropdown from "@/components/NavDropdown";
 import Link from "next/link";
@@ -25,6 +26,10 @@ export default async function EditEventPage({
   if (!data) notFound();
 
   const isAdmin = dbUser?.role === "admin";
+  const isPaidUser = canAccessPaidFeatures(
+    dbUser?.role ?? "user",
+    (dbUser?.billingPlan as "free" | "paid") ?? "free",
+  );
 
   return (
     <div className={styles.page}>
@@ -38,7 +43,7 @@ export default async function EditEventPage({
         </div>
       </header>
       <main className={styles.main}>
-        <EventForm initialData={{ event: data, birds: data.birds }} />
+        <EventForm initialData={{ event: data, birds: data.birds }} isPaidUser={isPaidUser} />
       </main>
     </div>
   );

--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -1,5 +1,6 @@
 import { requireVerifiedAuth } from "../../../lib/session";
 import { getUserById } from "../../../lib/dal/users";
+import { canAccessPaidFeatures } from "../../../lib/billing";
 import EventForm from "../../../components/EventForm";
 import NavDropdown from "../../../components/NavDropdown";
 import Link from "next/link";
@@ -9,6 +10,10 @@ export default async function NewEventPage() {
   const session = await requireVerifiedAuth();
   const dbUser = await getUserById(session.user.id);
   const isAdmin = dbUser?.role === "admin";
+  const isPaidUser = canAccessPaidFeatures(
+    dbUser?.role ?? "user",
+    (dbUser?.billingPlan as "free" | "paid") ?? "free",
+  );
 
   return (
     <div className={styles.page}>
@@ -22,7 +27,7 @@ export default async function NewEventPage() {
         </div>
       </header>
       <main className={styles.main}>
-        <EventForm />
+        <EventForm isPaidUser={isPaidUser} />
       </main>
     </div>
   );

--- a/src/components/AddBirdForm.tsx
+++ b/src/components/AddBirdForm.tsx
@@ -11,9 +11,10 @@ import { usePhotoIdentify } from "@/hooks/usePhotoIdentify";
 
 interface Props {
   eventId: number;
+  isPaidUser?: boolean;
 }
 
-export default function AddBirdForm({ eventId }: Props) {
+export default function AddBirdForm({ eventId, isPaidUser = false }: Props) {
   const router = useRouter();
   const [type, setType] = useState("");
   const [species, setSpecies] = useState("");
@@ -97,27 +98,29 @@ export default function AddBirdForm({ eventId }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
-      <DragDropZone
-        onFile={(file) => reader.readFile(file)}
-        onError={setPhotoError}
-        disabled={photoUploading}
-      >
-        <div className={styles.photoSection}>
-          <label className={styles.photoLabel}>Photo (optional)</label>
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handlePhotoChange}
-            disabled={photoUploading}
-            className={styles.photoInput}
-          />
-          {photoPreview && (
-            <img src={photoPreview} alt="Preview" className={styles.photoThumb} />
-          )}
-          {photoStatus && <span className={styles.photoStatus}>{photoStatus}</span>}
-          {photoError && <span className={styles.photoError}>{photoError}</span>}
-        </div>
-      </DragDropZone>
+      {isPaidUser && (
+        <DragDropZone
+          onFile={(file) => reader.readFile(file)}
+          onError={setPhotoError}
+          disabled={photoUploading}
+        >
+          <div className={styles.photoSection}>
+            <label className={styles.photoLabel}>Photo (optional)</label>
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handlePhotoChange}
+              disabled={photoUploading}
+              className={styles.photoInput}
+            />
+            {photoPreview && (
+              <img src={photoPreview} alt="Preview" className={styles.photoThumb} />
+            )}
+            {photoStatus && <span className={styles.photoStatus}>{photoStatus}</span>}
+            {photoError && <span className={styles.photoError}>{photoError}</span>}
+          </div>
+        </DragDropZone>
+      )}
 
       {!identify.identified && (
         <BirdChatWidget

--- a/src/components/BirdCard.tsx
+++ b/src/components/BirdCard.tsx
@@ -19,6 +19,7 @@ interface Props {
   record: BirdRecord;
   displayIndex: number;
   isEdit: boolean;
+  isPaidUser?: boolean;
   existingBirdId?: number;
   eventId?: number;
   onFieldChange: (field: keyof BirdFormEntry, value: string) => void;
@@ -41,6 +42,7 @@ export default function BirdCard({
   record,
   displayIndex,
   isEdit,
+  isPaidUser = false,
   existingBirdId,
   eventId,
   onFieldChange,
@@ -53,7 +55,7 @@ export default function BirdCard({
   const { formData, photo, geo } = record;
 
   const showEditLink = shouldShowEditLink(isEdit, existingBirdId, eventId);
-  const showPhotoSection = shouldShowPhotoSection(isEdit);
+  const showPhotoSection = shouldShowPhotoSection(isEdit) && isPaidUser;
   const showGeoButton = shouldShowGeoButton(isEdit);
   const showChatWidget = shouldShowChatWidget(isEdit, photo.identified);
 

--- a/src/components/BirdEditForm.tsx
+++ b/src/components/BirdEditForm.tsx
@@ -11,9 +11,10 @@ import { usePhotoReader } from "@/hooks/usePhotoReader";
 interface Props {
   bird: BirdEntry;
   returnTo?: string;
+  isPaidUser?: boolean;
 }
 
-export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
+export default function BirdEditForm({ bird, returnTo = "/dashboard", isPaidUser = false }: Props) {
   const router = useRouter();
   const [type, setType] = useState(bird.type);
   const [species, setSpecies] = useState(bird.species);
@@ -94,27 +95,29 @@ export default function BirdEditForm({ bird, returnTo = "/dashboard" }: Props) {
 
   return (
     <form onSubmit={handleSubmit} className={styles.form}>
-      <DragDropZone
-        onFile={(file) => reader.readFile(file)}
-        onError={setPhotoError}
-        disabled={reader.reading}
-      >
-        <div className={styles.photoSection}>
-          <label className={styles.photoLabel}>Photo (optional)</label>
-          {photoPreview && (
-            <img src={photoPreview} alt="Bird photo" className={styles.photoThumb} />
-          )}
-          <input
-            type="file"
-            accept="image/*"
-            onChange={handlePhotoChange}
-            disabled={reader.reading}
-            className={styles.photoInput}
-          />
-          {photoStatus && <span className={styles.photoStatus}>{photoStatus}</span>}
-          {photoError && <span className={styles.photoError}>{photoError}</span>}
-        </div>
-      </DragDropZone>
+      {isPaidUser && (
+        <DragDropZone
+          onFile={(file) => reader.readFile(file)}
+          onError={setPhotoError}
+          disabled={reader.reading}
+        >
+          <div className={styles.photoSection}>
+            <label className={styles.photoLabel}>Photo (optional)</label>
+            {photoPreview && (
+              <img src={photoPreview} alt="Bird photo" className={styles.photoThumb} />
+            )}
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handlePhotoChange}
+              disabled={reader.reading}
+              className={styles.photoInput}
+            />
+            {photoStatus && <span className={styles.photoStatus}>{photoStatus}</span>}
+            {photoError && <span className={styles.photoError}>{photoError}</span>}
+          </div>
+        </DragDropZone>
+      )}
 
       <div className={styles.grid}>
         <div className={styles.field}>

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -13,9 +13,10 @@ interface InitialData {
 
 interface Props {
   initialData?: InitialData;
+  isPaidUser?: boolean;
 }
 
-export default function EventForm({ initialData }: Props) {
+export default function EventForm({ initialData, isPaidUser = false }: Props) {
   const router = useRouter();
   const form = useEventForm({
     initialData: initialData
@@ -89,6 +90,7 @@ export default function EventForm({ initialData }: Props) {
             record={record}
             displayIndex={index}
             isEdit={form.isEdit}
+            isPaidUser={isPaidUser}
             existingBirdId={initialData?.birds[index]?.id}
             eventId={initialData?.event.id}
             onFieldChange={(field, value) =>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -11,6 +11,9 @@ export const user = sqliteTable("user", {
     .notNull(),
   image: text("image"),
   role: text("role", { enum: ["user", "admin"] }).default("user").notNull(),
+  billingPlan: text("billing_plan", { enum: ["free", "paid"] })
+    .default("free")
+    .notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -49,7 +49,7 @@ export const auth = betterAuth({
     },
     sendOnSignUp: true,
     autoSignInAfterVerification: true,
-    afterVerificationUrl: "/dashboard",
+    afterVerificationUrl: "/billing",
   },
   socialProviders: {
     google: {

--- a/src/lib/billing.ts
+++ b/src/lib/billing.ts
@@ -1,0 +1,65 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { user as userTable } from "@/db/schema";
+
+export type BillingPlan = "free" | "paid";
+
+const FREE_MODEL_DEFAULT = "openrouter/auto";
+const PAID_MODEL_DEFAULT = "openrouter/openai/gpt-oss-120b";
+
+/**
+ * Returns the user's billing plan from the database.
+ * Falls back to "free" if the user is not found.
+ */
+export async function getUserBillingPlan(userId: string): Promise<BillingPlan> {
+  const [row] = await db
+    .select({ billingPlan: userTable.billingPlan, role: userTable.role })
+    .from(userTable)
+    .where(eq(userTable.id, userId))
+    .limit(1);
+
+  return (row?.billingPlan as BillingPlan) ?? "free";
+}
+
+/**
+ * Returns the user's role and billing plan from the database.
+ * Returns null if the user is not found.
+ */
+export async function getUserBillingInfo(
+  userId: string,
+): Promise<{ role: string; billingPlan: BillingPlan } | null> {
+  const [row] = await db
+    .select({ billingPlan: userTable.billingPlan, role: userTable.role })
+    .from(userTable)
+    .where(eq(userTable.id, userId))
+    .limit(1);
+
+  if (!row) return null;
+  return { role: row.role, billingPlan: row.billingPlan as BillingPlan };
+}
+
+/**
+ * Returns true if the user can access paid features.
+ * Admins always have access. Paid plan users have access.
+ */
+export function canAccessPaidFeatures(
+  role: string,
+  billingPlan: BillingPlan,
+): boolean {
+  return role === "admin" || billingPlan === "paid";
+}
+
+/**
+ * Returns the appropriate chat model based on billing plan and role.
+ * Admins and paid users get the paid model.
+ * Free users get the free model.
+ */
+export function selectChatModel(
+  role: string,
+  billingPlan: BillingPlan,
+): string {
+  if (canAccessPaidFeatures(role, billingPlan)) {
+    return process.env.OPENROUTER_MODEL ?? PAID_MODEL_DEFAULT;
+  }
+  return process.env.OPENROUTER_FREE_MODEL ?? FREE_MODEL_DEFAULT;
+}

--- a/src/lib/dal/users.ts
+++ b/src/lib/dal/users.ts
@@ -1,12 +1,21 @@
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { user as userTable, birdingEvents, birdEntries } from "@/db/schema";
+import type { BillingPlan } from "@/lib/billing";
 
 export type User = typeof userTable.$inferSelect;
 
 /** Throws if the caller is not an admin. Use at the start of admin-only DAL functions. */
 function assertAdmin(callerRole: string): void {
   if (callerRole !== "admin") throw new Error("Forbidden: admin role required.");
+}
+
+/** Update the billing plan for a user. */
+export async function updateUserBillingPlan(userId: string, plan: BillingPlan): Promise<void> {
+  await db
+    .update(userTable)
+    .set({ billingPlan: plan })
+    .where(eq(userTable.id, userId));
 }
 
 /** Fetch a user by ID. Returns null if not found. */

--- a/src/tests/unit/billing.test.ts
+++ b/src/tests/unit/billing.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  canAccessPaidFeatures,
+  selectChatModel,
+  type BillingPlan,
+} from "@/lib/billing";
+
+// ──────────────────────────────────────────────────────────────────────────────
+// canAccessPaidFeatures
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("canAccessPaidFeatures", () => {
+  it("returns false for free user", () => {
+    expect(canAccessPaidFeatures("user", "free")).toBe(false);
+  });
+
+  it("returns true for paid user", () => {
+    expect(canAccessPaidFeatures("user", "paid")).toBe(true);
+  });
+
+  it("returns true for admin regardless of billing plan (free)", () => {
+    expect(canAccessPaidFeatures("admin", "free")).toBe(true);
+  });
+
+  it("returns true for admin with paid plan", () => {
+    expect(canAccessPaidFeatures("admin", "paid")).toBe(true);
+  });
+
+  it("returns false for unknown role with free plan", () => {
+    expect(canAccessPaidFeatures("guest", "free")).toBe(false);
+  });
+
+  it("returns true for unknown role with paid plan", () => {
+    expect(canAccessPaidFeatures("guest", "paid")).toBe(true);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// selectChatModel
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("selectChatModel", () => {
+  const originalModel = process.env.OPENROUTER_MODEL;
+  const originalFreeModel = process.env.OPENROUTER_FREE_MODEL;
+
+  beforeEach(() => {
+    delete process.env.OPENROUTER_MODEL;
+    delete process.env.OPENROUTER_FREE_MODEL;
+  });
+
+  afterEach(() => {
+    if (originalModel !== undefined) {
+      process.env.OPENROUTER_MODEL = originalModel;
+    } else {
+      delete process.env.OPENROUTER_MODEL;
+    }
+    if (originalFreeModel !== undefined) {
+      process.env.OPENROUTER_FREE_MODEL = originalFreeModel;
+    } else {
+      delete process.env.OPENROUTER_FREE_MODEL;
+    }
+  });
+
+  it("returns free model default for free user when no env vars set", () => {
+    const model = selectChatModel("user", "free");
+    expect(model).toBe("openrouter/auto");
+  });
+
+  it("returns paid model default for paid user when no env vars set", () => {
+    const model = selectChatModel("user", "paid");
+    expect(model).toBe("openrouter/openai/gpt-oss-120b");
+  });
+
+  it("returns paid model default for admin with free plan when no env vars set", () => {
+    const model = selectChatModel("admin", "free");
+    expect(model).toBe("openrouter/openai/gpt-oss-120b");
+  });
+
+  it("returns OPENROUTER_FREE_MODEL env var for free user", () => {
+    process.env.OPENROUTER_FREE_MODEL = "openrouter/mistral/mistral-7b";
+    const model = selectChatModel("user", "free");
+    expect(model).toBe("openrouter/mistral/mistral-7b");
+  });
+
+  it("returns OPENROUTER_MODEL env var for paid user", () => {
+    process.env.OPENROUTER_MODEL = "openrouter/anthropic/claude-3-5-sonnet";
+    const model = selectChatModel("user", "paid");
+    expect(model).toBe("openrouter/anthropic/claude-3-5-sonnet");
+  });
+
+  it("returns OPENROUTER_MODEL env var for admin with free plan (admin bypass)", () => {
+    process.env.OPENROUTER_MODEL = "openrouter/anthropic/claude-3-5-sonnet";
+    const model = selectChatModel("admin", "free");
+    expect(model).toBe("openrouter/anthropic/claude-3-5-sonnet");
+  });
+
+  it("uses OPENROUTER_FREE_MODEL for free user even if OPENROUTER_MODEL is set", () => {
+    process.env.OPENROUTER_MODEL = "openrouter/anthropic/claude-3-5-sonnet";
+    process.env.OPENROUTER_FREE_MODEL = "openrouter/mistral/mistral-7b";
+    const model = selectChatModel("user", "free");
+    expect(model).toBe("openrouter/mistral/mistral-7b");
+  });
+
+  it("uses OPENROUTER_MODEL for paid user even if OPENROUTER_FREE_MODEL is set", () => {
+    process.env.OPENROUTER_MODEL = "openrouter/anthropic/claude-3-5-sonnet";
+    process.env.OPENROUTER_FREE_MODEL = "openrouter/mistral/mistral-7b";
+    const model = selectChatModel("user", "paid");
+    expect(model).toBe("openrouter/anthropic/claude-3-5-sonnet");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Billing plan validation helpers (mirrors billing page / action logic)
+// ──────────────────────────────────────────────────────────────────────────────
+
+function isValidPlan(plan: unknown): plan is BillingPlan {
+  return plan === "free" || plan === "paid";
+}
+
+describe("isValidPlan", () => {
+  it("accepts 'free'", () => {
+    expect(isValidPlan("free")).toBe(true);
+  });
+
+  it("accepts 'paid'", () => {
+    expect(isValidPlan("paid")).toBe(true);
+  });
+
+  it("rejects unknown strings", () => {
+    expect(isValidPlan("enterprise")).toBe(false);
+  });
+
+  it("rejects null", () => {
+    expect(isValidPlan(null)).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isValidPlan(undefined)).toBe(false);
+  });
+
+  it("rejects numbers", () => {
+    expect(isValidPlan(1)).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Billing access scenarios (business rule table)
+// ──────────────────────────────────────────────────────────────────────────────
+
+describe("billing access scenarios", () => {
+  const scenarios: Array<{
+    label: string;
+    role: string;
+    plan: BillingPlan;
+    expectAccess: boolean;
+    expectModel: "free" | "paid";
+  }> = [
+    {
+      label: "regular free user",
+      role: "user",
+      plan: "free",
+      expectAccess: false,
+      expectModel: "free",
+    },
+    {
+      label: "regular paid user",
+      role: "user",
+      plan: "paid",
+      expectAccess: true,
+      expectModel: "paid",
+    },
+    {
+      label: "admin with free plan",
+      role: "admin",
+      plan: "free",
+      expectAccess: true,
+      expectModel: "paid",
+    },
+    {
+      label: "admin with paid plan",
+      role: "admin",
+      plan: "paid",
+      expectAccess: true,
+      expectModel: "paid",
+    },
+  ];
+
+  for (const { label, role, plan, expectAccess, expectModel } of scenarios) {
+    it(`${label} — canAccessPaidFeatures: ${expectAccess}`, () => {
+      expect(canAccessPaidFeatures(role, plan)).toBe(expectAccess);
+    });
+
+    it(`${label} — uses ${expectModel} AI model`, () => {
+      // Without env vars set, default model tier should match expectModel
+      const paidDefault = "openrouter/openai/gpt-oss-120b";
+      const freeDefault = "openrouter/auto";
+      const model = selectChatModel(role, plan);
+      const expected = expectModel === "paid" ? paidDefault : freeDefault;
+      expect(model).toBe(expected);
+    });
+  }
+});


### PR DESCRIPTION
- Add `billing_plan` column to users table (migration 0007, schema update)
- New `src/lib/billing.ts` with canAccessPaidFeatures, selectChatModel utilities
- Billing options page at /billing (server component, two plan cards)
- updateBillingPlan server action in app/billing/actions.ts
- Redirect afterVerificationUrl to /billing so new users choose a plan
- POST /api/identify-photo: returns 403 for free users (admin bypass)
- POST /api/chat: selects model by billing plan (free model vs paid model)
- AddBirdForm, BirdEditForm, BirdCard, EventForm: hide photo upload for free users
- OPENROUTER_FREE_MODEL env var added to .env.example
- 28 new billing unit tests; all 221 tests pass