### PR TITLE
feat(billing): DB schema + DAL foundation for cancel-at-period-end (#85)

### DIFF
--- a/drizzle/0011_add_cancel_at_period_end.sql
+++ b/drizzle/0011_add_cancel_at_period_end.sql
@@ -1,0 +1,3 @@
+-- Add cancellation scheduling columns to user table
+ALTER TABLE `user` ADD COLUMN `cancel_at_period_end` integer NOT NULL DEFAULT 0;
+ALTER TABLE `user` ADD COLUMN `current_period_end` integer;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -26,6 +26,10 @@ export const user = sqliteTable("user", {
     .default(0)
     .notNull(),
   extraUsageCents: integer("extra_usage_cents").default(0).notNull(),
+  cancelAtPeriodEnd: integer("cancel_at_period_end", { mode: "boolean" })
+    .default(false)
+    .notNull(),
+  currentPeriodEnd: integer("current_period_end"),
   createdAt: integer("created_at", { mode: "timestamp_ms" })
     .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`)
     .notNull(),

--- a/src/lib/dal/billing.ts
+++ b/src/lib/dal/billing.ts
@@ -9,6 +9,8 @@ export const PRO_LIMIT_CENTS = 400; // $4.00
 
 /**
  * Log a usage entry and increment the user's current month usage.
+ * If the user is in drain state (paid plan, no active subscription, extra usage exhausted),
+ * flip billing_plan to "free".
  */
 export async function logUsage(
   userId: string,
@@ -23,6 +25,36 @@ export async function logUsage(
       currentMonthUsageCents: sql`${userTable.currentMonthUsageCents} + ${costCents}`,
     })
     .where(eq(userTable.id, userId));
+
+  // Drain state: subscription canceled (no stripeSubscriptionId) but extra usage remained.
+  // When limit is now exhausted, flip to free.
+  const [row] = await db
+    .select({
+      billingPlan: userTable.billingPlan,
+      stripeSubscriptionId: userTable.stripeSubscriptionId,
+      subscriptionStatus: userTable.subscriptionStatus,
+      currentMonthUsageCents: userTable.currentMonthUsageCents,
+      extraUsageCents: userTable.extraUsageCents,
+    })
+    .from(userTable)
+    .where(eq(userTable.id, userId))
+    .limit(1);
+
+  // Drain state: subscription explicitly canceled (stripeSubscriptionId nulled out,
+  // subscriptionStatus="canceled") but user kept on paid plan due to remaining extra credits.
+  // When extra credits are now exhausted, flip to free.
+  if (
+    row &&
+    row.billingPlan === "paid" &&
+    row.stripeSubscriptionId === null &&
+    row.subscriptionStatus === "canceled" &&
+    row.currentMonthUsageCents >= PRO_LIMIT_CENTS + (row.extraUsageCents ?? 0)
+  ) {
+    await db
+      .update(userTable)
+      .set({ billingPlan: "free" })
+      .where(eq(userTable.id, userId));
+  }
 }
 
 /**
@@ -167,12 +199,13 @@ export async function getUserIdByStripeCustomerId(
 
 /**
  * Activate subscription: set billing plan to "paid", subscription status to "active",
- * and save the stripe customer ID and subscription ID.
+ * save stripe IDs, reset cancelAtPeriodEnd, and optionally store currentPeriodEnd.
  */
 export async function activateSubscription(
   userId: string,
   stripeCustomerId: string,
   stripeSubscriptionId: string,
+  currentPeriodEnd?: number,
 ): Promise<void> {
   await db
     .update(userTable)
@@ -181,22 +214,37 @@ export async function activateSubscription(
       stripeCustomerId,
       stripeSubscriptionId,
       subscriptionStatus: "active",
+      cancelAtPeriodEnd: false,
+      ...(currentPeriodEnd !== undefined ? { currentPeriodEnd } : {}),
     })
     .where(eq(userTable.id, userId));
 }
 
 /**
- * Cancel subscription by Stripe customer ID: set billing plan to "free",
- * subscription status to "canceled".
+ * Cancel subscription by Stripe customer ID.
+ * If extra_usage_cents > 0, keeps billing_plan="paid" (drain state) and nulls stripeSubscriptionId.
+ * If extra_usage_cents = 0, flips billing_plan to "free".
+ * Always clears cancelAtPeriodEnd and currentPeriodEnd.
  */
 export async function cancelSubscriptionByCustomerId(
   stripeCustomerId: string,
 ): Promise<void> {
+  const [row] = await db
+    .select({ extraUsageCents: userTable.extraUsageCents })
+    .from(userTable)
+    .where(eq(userTable.stripeCustomerId, stripeCustomerId))
+    .limit(1);
+
+  const inDrainState = (row?.extraUsageCents ?? 0) > 0;
+
   await db
     .update(userTable)
     .set({
-      billingPlan: "free",
+      billingPlan: inDrainState ? "paid" : "free",
       subscriptionStatus: "canceled",
+      stripeSubscriptionId: null,
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd: null,
     })
     .where(eq(userTable.stripeCustomerId, stripeCustomerId));
 }
@@ -216,13 +264,57 @@ export async function pauseSubscriptionByCustomerId(
 
 /**
  * Reset the current month usage to 0 for a specific user.
- * Called on subscription renewal — extra usage carries over to the next month.
+ * Optionally updates currentPeriodEnd (called on subscription renewal).
+ * Extra usage carries over to the next month.
  */
-export async function resetMonthlyUsage(userId: string): Promise<void> {
+export async function resetMonthlyUsage(
+  userId: string,
+  currentPeriodEnd?: number,
+): Promise<void> {
   await db
     .update(userTable)
-    .set({ currentMonthUsageCents: 0 })
+    .set({
+      currentMonthUsageCents: 0,
+      ...(currentPeriodEnd !== undefined ? { currentPeriodEnd } : {}),
+    })
     .where(eq(userTable.id, userId));
+}
+
+/**
+ * Schedule cancellation at period end by Stripe customer ID.
+ * Sets cancelAtPeriodEnd=true, stores currentPeriodEnd, and marks subscriptionStatus="canceled".
+ */
+export async function scheduleCancellation(
+  stripeCustomerId: string,
+  currentPeriodEnd: number,
+): Promise<void> {
+  await db
+    .update(userTable)
+    .set({
+      cancelAtPeriodEnd: true,
+      currentPeriodEnd,
+      subscriptionStatus: "canceled",
+    })
+    .where(eq(userTable.stripeCustomerId, stripeCustomerId));
+}
+
+/**
+ * Reactivate a subscription that was scheduled for cancellation.
+ * Sets cancelAtPeriodEnd=false, updates currentPeriodEnd, and marks subscriptionStatus="active".
+ * Does NOT reset usage.
+ */
+export async function reactivateSubscription(
+  stripeCustomerId: string,
+  currentPeriodEnd: number,
+): Promise<void> {
+  await db
+    .update(userTable)
+    .set({
+      cancelAtPeriodEnd: false,
+      currentPeriodEnd,
+      subscriptionStatus: "active",
+    })
+    .where(eq(userTable.stripeCustomerId, stripeCustomerId));
 }
 
 /**
@@ -235,6 +327,8 @@ export async function getBillingInfo(userId: string): Promise<{
   stripeSubscriptionId: string | null;
   currentMonthUsageCents: number;
   extraUsageCents: number;
+  cancelAtPeriodEnd: boolean;
+  currentPeriodEnd: number | null;
 } | null> {
   const [row] = await db
     .select({
@@ -244,6 +338,8 @@ export async function getBillingInfo(userId: string): Promise<{
       stripeSubscriptionId: userTable.stripeSubscriptionId,
       currentMonthUsageCents: userTable.currentMonthUsageCents,
       extraUsageCents: userTable.extraUsageCents,
+      cancelAtPeriodEnd: userTable.cancelAtPeriodEnd,
+      currentPeriodEnd: userTable.currentPeriodEnd,
     })
     .from(userTable)
     .where(eq(userTable.id, userId))

--- a/src/tests/unit/billingDal.test.ts
+++ b/src/tests/unit/billingDal.test.ts
@@ -33,6 +33,11 @@ import {
   setStripeCustomerId,
   setStripeSubscriptionId,
   resetMonthlyUsage,
+  getBillingInfo,
+  activateSubscription,
+  cancelSubscriptionByCustomerId,
+  scheduleCancellation,
+  reactivateSubscription,
   PRO_LIMIT_CENTS,
 } from "@/lib/dal/billing";
 
@@ -60,6 +65,8 @@ beforeAll(async () => {
       spending_limit_cents        integer,
       current_month_usage_cents   integer NOT NULL DEFAULT 0,
       extra_usage_cents           integer NOT NULL DEFAULT 0,
+      cancel_at_period_end        integer NOT NULL DEFAULT 0,
+      current_period_end          integer,
       created_at                  integer NOT NULL DEFAULT 0,
       updated_at                  integer NOT NULL DEFAULT 0
     )
@@ -113,7 +120,10 @@ beforeEach(async () => {
             extra_usage_cents = 0,
             stripe_customer_id = NULL,
             stripe_subscription_id = NULL,
-            subscription_status = NULL
+            subscription_status = NULL,
+            billing_plan = 'paid',
+            cancel_at_period_end = 0,
+            current_period_end = NULL
           WHERE id IN (?, ?)`,
     args: [USER_ID, USER_ID_2],
   });
@@ -398,5 +408,255 @@ describe("resetMonthlyUsage", () => {
       args: [USER_ID_2],
     });
     expect(rows.rows[0][0]).toBe(50);
+  });
+
+  it("stores updated currentPeriodEnd when provided", async () => {
+    const periodEnd = 1800000000;
+    await resetMonthlyUsage(USER_ID, periodEnd);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT current_period_end FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(periodEnd);
+  });
+
+  it("does not change currentPeriodEnd when not provided", async () => {
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET current_period_end = 1700000000 WHERE id = ?`,
+      args: [USER_ID],
+    });
+    await resetMonthlyUsage(USER_ID);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT current_period_end FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(1700000000);
+  });
+});
+
+// ── activateSubscription ──────────────────────────────────────────────────────
+describe("activateSubscription", () => {
+  it("sets billing_plan to paid, subscription status to active", async () => {
+    await activateSubscription(USER_ID, "cus_act1", "sub_act1");
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan, subscription_status FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("paid");
+    expect(rows.rows[0][1]).toBe("active");
+  });
+
+  it("stores currentPeriodEnd when provided", async () => {
+    const periodEnd = 1750000000;
+    await activateSubscription(USER_ID, "cus_act2", "sub_act2", periodEnd);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT current_period_end, cancel_at_period_end FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(periodEnd);
+    expect(rows.rows[0][1]).toBe(0);
+  });
+
+  it("resets cancelAtPeriodEnd to false", async () => {
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET cancel_at_period_end = 1 WHERE id = ?`,
+      args: [USER_ID],
+    });
+    await activateSubscription(USER_ID, "cus_act3", "sub_act3");
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT cancel_at_period_end FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(0);
+  });
+});
+
+// ── getBillingInfo (new fields) ───────────────────────────────────────────────
+describe("getBillingInfo (new fields)", () => {
+  it("returns cancelAtPeriodEnd=false and currentPeriodEnd=null by default", async () => {
+    const info = await getBillingInfo(USER_ID);
+    expect(info).not.toBeNull();
+    expect(info!.cancelAtPeriodEnd).toBe(false);
+    expect(info!.currentPeriodEnd).toBeNull();
+  });
+
+  it("returns cancelAtPeriodEnd=true when set", async () => {
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET cancel_at_period_end = 1, current_period_end = 1800000000 WHERE id = ?`,
+      args: [USER_ID],
+    });
+    const info = await getBillingInfo(USER_ID);
+    expect(info!.cancelAtPeriodEnd).toBe(true);
+    expect(info!.currentPeriodEnd).toBe(1800000000);
+  });
+});
+
+// ── scheduleCancellation ──────────────────────────────────────────────────────
+describe("scheduleCancellation", () => {
+  it("sets cancelAtPeriodEnd=true, currentPeriodEnd, and subscriptionStatus=canceled", async () => {
+    await setStripeCustomerId(USER_ID, "cus_sched1");
+    const periodEnd = 1790000000;
+    await scheduleCancellation("cus_sched1", periodEnd);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT cancel_at_period_end, current_period_end, subscription_status FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(1);
+    expect(rows.rows[0][1]).toBe(periodEnd);
+    expect(rows.rows[0][2]).toBe("canceled");
+  });
+
+  it("only affects the user matching the stripeCustomerId", async () => {
+    await setStripeCustomerId(USER_ID, "cus_sched2");
+    await scheduleCancellation("cus_sched2", 1790000000);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT cancel_at_period_end FROM "user" WHERE id = ?`,
+      args: [USER_ID_2],
+    });
+    expect(rows.rows[0][0]).toBe(0);
+  });
+});
+
+// ── reactivateSubscription ────────────────────────────────────────────────────
+describe("reactivateSubscription", () => {
+  it("sets cancelAtPeriodEnd=false, updates currentPeriodEnd, and subscriptionStatus=active", async () => {
+    await setStripeCustomerId(USER_ID, "cus_react1");
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET cancel_at_period_end = 1, current_period_end = 1700000000, subscription_status = 'canceled' WHERE id = ?`,
+      args: [USER_ID],
+    });
+
+    const newPeriodEnd = 1820000000;
+    await reactivateSubscription("cus_react1", newPeriodEnd);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT cancel_at_period_end, current_period_end, subscription_status FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(0);
+    expect(rows.rows[0][1]).toBe(newPeriodEnd);
+    expect(rows.rows[0][2]).toBe("active");
+  });
+
+  it("does NOT reset current month usage", async () => {
+    await setStripeCustomerId(USER_ID, "cus_react2");
+    await logUsage(USER_ID, "openrouter/auto", 150);
+    await reactivateSubscription("cus_react2", 1820000000);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT current_month_usage_cents FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe(150);
+  });
+});
+
+// ── cancelSubscriptionByCustomerId (drain logic) ──────────────────────────────
+describe("cancelSubscriptionByCustomerId (drain logic)", () => {
+  it("flips billing_plan to free when extra_usage_cents is 0", async () => {
+    await setStripeCustomerId(USER_ID, "cus_cancel1");
+    await cancelSubscriptionByCustomerId("cus_cancel1");
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan, stripe_subscription_id FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("free");
+    expect(rows.rows[0][1]).toBeNull();
+  });
+
+  it("keeps billing_plan as paid (drain state) when extra_usage_cents > 0", async () => {
+    await setStripeCustomerId(USER_ID, "cus_cancel2");
+    await addExtraUsage(USER_ID, 500);
+    await cancelSubscriptionByCustomerId("cus_cancel2");
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan, stripe_subscription_id FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("paid");
+    expect(rows.rows[0][1]).toBeNull();
+  });
+
+  it("always nulls stripeSubscriptionId and clears cancelAtPeriodEnd and currentPeriodEnd", async () => {
+    await setStripeCustomerId(USER_ID, "cus_cancel3");
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET stripe_subscription_id = 'sub_old', cancel_at_period_end = 1, current_period_end = 1700000000 WHERE id = ?`,
+      args: [USER_ID],
+    });
+    await cancelSubscriptionByCustomerId("cus_cancel3");
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT stripe_subscription_id, cancel_at_period_end, current_period_end FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBeNull();
+    expect(rows.rows[0][1]).toBe(0);
+    expect(rows.rows[0][2]).toBeNull();
+  });
+});
+
+// ── logUsage drain state flip ─────────────────────────────────────────────────
+describe("logUsage drain state flip", () => {
+  it("flips billing_plan to free when drain-state user hits the usage limit", async () => {
+    // Drain state: subscription canceled, stripeSubscriptionId=null, extra_usage > 0
+    await addExtraUsage(USER_ID, 100); // total budget = 400 + 100 = 500
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET subscription_status = 'canceled' WHERE id = ?`,
+      args: [USER_ID],
+    });
+    await logUsage(USER_ID, "openrouter/auto", 500);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("free");
+  });
+
+  it("does NOT flip billing_plan when active subscription user hits limit", async () => {
+    // Active subscription: stripeSubscriptionId is set
+    await setStripeSubscriptionId(USER_ID, "sub_active");
+    await logUsage(USER_ID, "openrouter/auto", 500);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("paid");
+  });
+
+  it("does NOT flip billing_plan for drain-state user below limit", async () => {
+    await addExtraUsage(USER_ID, 200); // budget = 400 + 200 = 600
+    await testState.client!.execute({
+      sql: `UPDATE "user" SET subscription_status = 'canceled' WHERE id = ?`,
+      args: [USER_ID],
+    });
+    await logUsage(USER_ID, "openrouter/auto", 400); // usage = 400, below 600
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("paid");
+  });
+
+  it("does NOT flip billing_plan for paid user with null subscriptionStatus", async () => {
+    // User has no subscription set (fresh signup) — not drain state
+    await addExtraUsage(USER_ID, 200);
+    await logUsage(USER_ID, "openrouter/auto", 600);
+
+    const rows = await testState.client!.execute({
+      sql: `SELECT billing_plan FROM "user" WHERE id = ?`,
+      args: [USER_ID],
+    });
+    expect(rows.rows[0][0]).toBe("paid");
   });
 });


### PR DESCRIPTION
- Migration 0011: adds cancel_at_period_end (boolean, default false) and current_period_end (nullable integer, Unix seconds) to user table
- schema.ts: new Drizzle column definitions for both fields
- billing.ts: scheduleCancellation, reactivateSubscription (new functions); getBillingInfo returns new fields; cancelSubscriptionByCustomerId implements drain-state logic (keeps paid plan when extra_usage_cents > 0, nulls stripeSubscriptionId); activateSubscription + resetMonthlyUsage accept optional currentPeriodEnd; logUsage flips to free in drain state on limit
- billingDal.test.ts: 18 new tests covering all new behaviors (49 total, all pass)